### PR TITLE
Updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ cp .env.sample .env
 Add the missing configuration values to the new `.env` file:
 
 #### Environment
-Set `PIXL_ENV` to `<environment>`.
+Set `ENV` to `<environment>`.
 
 #### Credentials
 - `EMAP_DB_`*  


### PR DESCRIPTION
README now correctly references `ENV` instead of `PIXL_ENV`
