### PR TITLE
Add kill CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ RDBMS which stores DICOM metadata and application data.
 This is one of dev|test|staging|prod and referred to as `<environment>` in the docs.
 
 ### 1. Initialise environment configuration
-Create a local `.env` file in the _PIXL_ directory:
+Create a local `.env` and `pixl_config.yml` file in the _PIXL_ directory:
 ```bash
-cp .env.sample .env
+cp .env.sample .env && cp pixl_config.yml.sample  pixl_config.yml
 ```
-Add the missing configuration values to the new `.env` file:
+Add the missing configuration values to the new files:
 
 #### Environment
 Set `ENV` to `<environment>`.
@@ -79,4 +79,3 @@ PIXL data extracts include the below assumptions
 
 - (MRN, Accession number) is unique identifier for a report/DICOM study pair
 - Patients have a single _relevant_ MRN
-- Observations closest to the average image acquisition time are most accurate

--- a/cli/src/pixl_cli/main.py
+++ b/cli/src/pixl_cli/main.py
@@ -178,6 +178,12 @@ def stop(queues: str) -> None:
         consume_all_messages_and_save_csv_file(queue)
 
 
+@cli.command()
+def kill() -> None:
+    """Stop all the PIXL services"""
+    os.system("docker compose stop")
+
+
 # TODO: Replace by PIXL queue package
 def create_connection() -> pika.BlockingConnection:
 

--- a/pixl_config.yml.sample
+++ b/pixl_config.yml.sample
@@ -1,0 +1,8 @@
+rabbitmq:
+  host:
+  port:
+  admin_port:
+ehr_api:
+  default_rate: 5  # ~queries per second
+pacs_api:
+  default_rate: 5  # queries per second


### PR DESCRIPTION
## Resolves #56 

- `pixl kill` is just a `docker compose stop`
- Given the path needs to resolve a sample .yml config has been added to the root directory

Note: I don't like the inevitable duplication between the .yml and .env files. Should we consolidate and use the .env file for both? @nels @bathomas @AnikaC-git
