### PR TITLE
Always delete stale state file

### DIFF
--- a/cli/src/pixl_cli/_utils.py
+++ b/cli/src/pixl_cli/_utils.py
@@ -11,6 +11,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+import os
 from pathlib import Path
 
 
@@ -22,3 +23,9 @@ def clear_file(filepath: Path) -> None:
 def string_is_non_empty(string: str) -> bool:
     """Does a string have more than just spaces and newlines?"""
     return len(string.split()) > 0
+
+
+def remove_file_if_it_exists(filepath: Path) -> None:
+    """If a file exists remove it"""
+    if filepath.exists():
+        os.remove(filepath)

--- a/cli/src/pixl_cli/_version.py
+++ b/cli/src/pixl_cli/_version.py
@@ -12,5 +12,5 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-__version_info__ = ("0", "0", "1")
+__version_info__ = ("0", "0", "2")
 __version__ = ".".join(__version_info__)


### PR DESCRIPTION
Suggested by @AnikaC-git – this PR alters the CLI restart functionality to always remove the state file after publishing messages onto the queue because it will be stale (i.e. not representative of messages not present on the queue)