### PR TITLE
Add `postgresql` installation instructions

### DIFF
--- a/pixl_ehr/README.md
+++ b/pixl_ehr/README.md
@@ -7,6 +7,24 @@ postgres database.
 
 ## Installation
 
+First, make sure you have `postgresql` installed on your system.
+
+On macOS:
+
+```bash
+brew install postgresql
+```
+
+On Ubuntu:
+
+```bash
+sudo apt install postgresql
+```
+
+On Windows, follow [these instructions](https://www.postgresqltutorial.com/postgresql-getting-started/install-postgresql/).
+
+Then install the Python dependencies with
+
 ```bash
 pip install -e ../pixl_core/ .
 python -m spacy download en_core_web_lg  # Download spacy language model for deidentification


### PR DESCRIPTION
Was running into installation issues when trying to install the dependencies for `pixl_ehr`.
Turns out I didn't have `postgresql` installed. So added it to the README.