### PR TITLE
Update `pixl_dcmd` requirements

### DIFF
--- a/pixl_dcmd/src/requirements.txt
+++ b/pixl_dcmd/src/requirements.txt
@@ -8,6 +8,6 @@ mypy==0.991
 pytest==7.1.3
 logger==1.4
 pyyaml==6.0
-requests==2.28.1
+requests==2.31.0
 python-decouple==3.6
 types-requests==2.28.*


### PR DESCRIPTION
`requests==2.28.1` was giving a dependency conflict with `hasher`.