### PR TITLE
Do we really need this dependency when it's in pixl core? Let's find

### DIFF
--- a/pixl_ehr/pyproject.toml
+++ b/pixl_ehr/pyproject.toml
@@ -17,7 +17,6 @@ dependencies = [
     "psycopg2==2.9.5",
     "azure-identity==1.12.0",
     "azure-storage-blob==12.14.1",
-    "pyarrow==14.0.1",
     "PyYAML==6.0",
 ]
 


### PR DESCRIPTION
out.