### PR TITLE
pacs-api container was trying to connect to rabbitmq before it was up

### DIFF
--- a/cli/tests/docker-compose.yml
+++ b/cli/tests/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - "5672:5672"
       - "15672:15672"
     healthcheck:
-      test: rabbitmq-diagnostics -q ping
+      test: rabbitmq-diagnostics -q check_running
       interval: 30s
       timeout: 30s
       retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -201,7 +201,7 @@ services:
       RABBITMQ_DEFAULT_USER: ${RABBITMQ_USERNAME}
       RABBITMQ_DEFAULT_PASS: ${RABBITMQ_PASSWORD}
     healthcheck:
-      test: rabbitmq-diagnostics -q ping
+      test: rabbitmq-diagnostics -q check_running
       interval: 30s
       timeout: 30s
       retries: 3

--- a/pixl_core/tests/docker-compose.yml
+++ b/pixl_core/tests/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       - "25672:5672"
       - "35672:15672"
     healthcheck:
-      test: rabbitmq-diagnostics -q ping
+      test: rabbitmq-diagnostics -q check_running
       interval: 10s
       timeout: 5s
       retries: 5

--- a/pixl_ehr/tests/docker-compose.yml
+++ b/pixl_ehr/tests/docker-compose.yml
@@ -62,7 +62,7 @@ services:
     container_name: pixl-test-queue
     image: rabbitmq:3.11.2-management
     healthcheck:
-      test: rabbitmq-diagnostics -q ping
+      test: rabbitmq-diagnostics -q check_running
       interval: 30s
       timeout: 30s
       retries: 3

--- a/pixl_pacs/tests/docker-compose.yml
+++ b/pixl_pacs/tests/docker-compose.yml
@@ -95,7 +95,7 @@ services:
     container_name: pixl-test-queue
     image: rabbitmq:3.11.2-management
     healthcheck:
-      test: rabbitmq-diagnostics -q ping
+      test: rabbitmq-diagnostics -q check_running
       interval: 30s
       timeout: 30s
       retries: 3


### PR DESCRIPTION
Although I never saw this fail on GHA, this failed very frequently on my Mac, such that the system test could not be run at all.

From pacs-api log:
```
2024-01-25T16:56:18.017005033Z ConnectionRefusedError:
2024-01-25T16:56:18.017461088Z ConnectionError: 
```

From queue log:
```
2024-01-25 16:56:32.718210+00:00 [info] <0.730.0> Server startup complete; 4 plugins started.
```

Ie. connection was attempted 14 seconds before server was ready.

Given:
```
2024-01-25 18:16:46.560534+00:00 [info] <0.752.0> Server startup complete; 4 plugins started.
```

A quick experiment with the `rabbitmq-diagnostics` command showed that:
```
Thu 25 Jan 2024 18:16:45 GMT
+ docker exec 4e67f53ede32 rabbitmq-diagnostics -q check_running
Error:
RabbitMQ on node rabbit@4e67f53ede32 is not running or has not fully booted yet (check with is_booting)
+ echo rc 69
+ docker exec 4e67f53ede32 rabbitmq-diagnostics -q status
+ echo rc 0
+ docker exec 4e67f53ede32 rabbitmq-diagnostics -q ping
+ echo rc 0

Thu 25 Jan 2024 18:16:47 GMT
+ docker exec 4e67f53ede32 rabbitmq-diagnostics -q check_running
+ echo rc 0 
+ docker exec 4e67f53ede32 rabbitmq-diagnostics -q status
+ echo rc 0 
+ docker exec 4e67f53ede32 rabbitmq-diagnostics -q ping
+ echo rc 0
```

Ie. before the server became ready, the only command that (correctly) fails is `rabbitmq-diagnostics -q check_running`, hence my choice. `rabbitmq-diagnostics -q ping` returns success for many seconds before the server is ready!