### PR TITLE
Jstutters/dependabot-2-update-fastapi-to-0.190.1

### DIFF
--- a/hasher/pyproject.toml
+++ b/hasher/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
 dependencies = [
     "azure-identity==1.12.0",
     "azure-keyvault==4.2.0",
-    "fastapi==0.103.2",
+    "fastapi==0.109.1",
     "hypothesis==6.56.0",
     "environs==9.5.0",
     "requests==2.31.0",

--- a/pixl_core/pyproject.toml
+++ b/pixl_core/pyproject.toml
@@ -11,7 +11,7 @@ classifiers = [
     "Programming Language :: Python :: 3"
 ]
 dependencies = [
-    "fastapi==0.103.2",
+    "fastapi==0.109.1",
     "token-bucket==0.3.0",
     "python-decouple==3.6",
     "python-slugify==8.0.1",

--- a/test/dummy-services/cogstack/pyproject.toml
+++ b/test/dummy-services/cogstack/pyproject.toml
@@ -10,7 +10,7 @@ classifiers = [
     "Programming Language :: Python :: 3"
 ]
 dependencies = [
-    "fastapi==0.103.2",
+    "fastapi==0.109.1",
     "uvicorn==0.23.2",
 ]
 


### PR DESCRIPTION
Updates FastAPI in core, hasher and test services to v0.109.1 to address
https://github.com/UCLH-Foundry/PIXL/security/dependabot/2