### PR TITLE
FTP upload preserving directory structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,3 +248,35 @@ PIXL data extracts include the below assumptions
 
 - (MRN, Accession number) is unique identifier for a report/DICOM study pair
 - Patients have a single _relevant_ MRN
+
+
+
+## File journey overview
+Files that are present at each step of the pipeline.
+
+### Resources in source repo (for test only)
+```
+test/resources/omop/public /*.parquet
+....................private/*.parquet
+....................extract_summary.json
+```
+
+### OMOP ES extract dir (input to PIXL)
+EXTRACT_DIR is the directory passed to `pixl populate`
+```
+EXTRACT_DIR/public /*.parquet
+............private/*.parquet
+............extract_summary.json
+```
+
+### PIXL Export dir (PIXL intermediate)
+```
+EXPORT_ROOT/PROJECT_SLUG/all_extracts/EXTRACT_DATETIME/radiology/radiology.parquet
+....................................................../omop/public/*.parquet
+```
+
+### FTP server
+```
+FTPROOT/PROJECT_SLUG/EXTRACT_DATETIME/parquet/radiology/radiology.parquet
+..............................................omop/public/*.parquet
+```

--- a/pixl_core/pyproject.toml
+++ b/pixl_core/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "sqlalchemy==2.0.24",
     "psycopg2-binary==2.9.9",
     "pandas==1.5.1",
+    "pyarrow==14.0.1",
 ]
 
 [project.optional-dependencies]

--- a/pixl_core/src/core/upload.py
+++ b/pixl_core/src/core/upload.py
@@ -20,6 +20,7 @@ import logging
 import ssl
 from datetime import datetime, timezone
 from ftplib import FTP_TLS
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, BinaryIO
 
 from decouple import config
@@ -88,23 +89,34 @@ def upload_dicom_image(zip_content: BinaryIO, pseudo_anon_id: str) -> None:
 
 def upload_parquet_files(parquet_export: ParquetExport) -> None:
     """Upload parquet to FTPS under <project name>/<extract datetime>/parquet."""
-    current_extract = parquet_export.public_output.parents[1]
+    source_root_dir = parquet_export.current_extract_base
     # Create the remote directory if it doesn't exist
     ftp = _connect_to_ftp()
     _create_and_set_as_cwd(ftp, parquet_export.project_slug)
     _create_and_set_as_cwd(ftp, parquet_export.extract_time_slug)
     _create_and_set_as_cwd(ftp, "parquet")
 
-    export_files = [x for x in current_extract.rglob("*.parquet") if x.is_file()]
-    if not export_files:
-        msg = f"No files found in {current_extract}"
+    # get the upload root directory before we do anything as we'll need
+    # to return to it (will it always be absolute?)
+    upload_root_dir = Path(ftp.pwd())
+    if not upload_root_dir.is_absolute():
+        logger.error("server remote path is not absolute, what are we going to do?")
+
+    # absolute paths of the source
+    source_files = [x for x in source_root_dir.rglob("*.parquet") if x.is_file()]
+    if not source_files:
+        msg = f"No files found in {source_root_dir}"
         raise FileNotFoundError(msg)
 
     # throw exception if empty dir
-    for path in export_files:
-        with path.open("rb") as handle:
-            command = f"STOR {path.stem}.parquet"
-            logger.debug("Running %s", command)
+    for source_path in source_files:
+        _create_and_set_as_cwd(ftp, str(upload_root_dir))
+        source_rel_path = source_path.relative_to(source_root_dir)
+        source_rel_dir = source_rel_path.parent
+        source_filename_only = source_rel_path.relative_to(source_rel_dir)
+        _create_and_set_as_cwd_multi_path(ftp, source_rel_dir)
+        with source_path.open("rb") as handle:
+            command = f"STOR {source_filename_only}"
 
             # Store the file using a binary handler
             ftp.storbinary(command, handle)
@@ -131,6 +143,19 @@ def _connect_to_ftp() -> FTP_TLS:
         error_msg = "Failed to connect to FTPS server: '%s'"
         raise ConnectionError(error_msg, ftp_error) from ftp_error
     return ftp
+
+
+def _create_and_set_as_cwd_multi_path(ftp: FTP_TLS, remote_multi_dir: Path) -> None:
+    """Create (and cwd into) a multi dir path, analogously to mkdir -p"""
+    if remote_multi_dir.is_absolute():
+        # would require some special handling and we don't need it
+        err = "must be relative path"
+        raise ValueError(err)
+    logger.info("_create_and_set_as_cwd_multi_path %s", remote_multi_dir)
+    # path should be pretty normalised, so assume split is safe
+    sub_dirs = str(remote_multi_dir).split("/")
+    for sd in sub_dirs:
+        _create_and_set_as_cwd(ftp, sd)
 
 
 def _create_and_set_as_cwd(ftp: FTP_TLS, project_dir: str) -> None:

--- a/pixl_core/tests/test_upload.py
+++ b/pixl_core/tests/test_upload.py
@@ -12,11 +12,11 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 """Test functionality to upload files to an endpoint."""
-
-
+import filecmp
 import pathlib
 from datetime import datetime, timezone
 
+import pandas as pd
 import pytest
 from core.db.models import Image
 from core.db.queries import get_project_slug_from_db, update_exported_at
@@ -75,8 +75,7 @@ def test_upload_parquet(parquet_export, ftps_home_dir) -> None:
     parquet_export.copy_to_exports(
         pathlib.Path(__file__).parents[2] / "test" / "resources" / "omop"
     )
-    with (parquet_export.public_output.parent / "radiology.parquet").open("w") as handle:
-        handle.writelines(["dummy data"])
+    parquet_export.export_radiology(pd.DataFrame(list("dummy"), columns=["D"]))
 
     # ACT
     upload_parquet_files(parquet_export)
@@ -85,8 +84,14 @@ def test_upload_parquet(parquet_export, ftps_home_dir) -> None:
         ftps_home_dir / parquet_export.project_slug / parquet_export.extract_time_slug / "parquet"
     )
     assert expected_public_parquet_dir.exists()
-    assert (expected_public_parquet_dir / "PROCEDURE_OCCURRENCE.parquet").exists()
-    assert (expected_public_parquet_dir / "radiology.parquet").exists()
+
+    # Print difference report to aid debugging (it doesn't actually assert anything)
+    dc = filecmp.dircmp(parquet_export.current_extract_base, expected_public_parquet_dir)
+    dc.report_full_closure()
+    assert (
+        expected_public_parquet_dir / "omop" / "public" / "PROCEDURE_OCCURRENCE.parquet"
+    ).exists()
+    assert (expected_public_parquet_dir / "radiology" / "radiology.parquet").exists()
 
 
 @pytest.mark.usefixtures("ftps_server")

--- a/pixl_core/tests/test_upload.py
+++ b/pixl_core/tests/test_upload.py
@@ -23,7 +23,7 @@ from core.db.queries import get_project_slug_from_db, update_exported_at
 from core.upload import upload_dicom_image, upload_parquet_files
 
 
-@pytest.mark.usefixtures("run_containers", "ftps_server")
+@pytest.mark.usefixtures("ftps_server")
 def test_upload_dicom_image(test_zip_content, not_yet_exported_dicom_image, ftps_home_dir) -> None:
     """Tests that DICOM image can be uploaded to the correct location"""
     # ARRANGE
@@ -39,7 +39,7 @@ def test_upload_dicom_image(test_zip_content, not_yet_exported_dicom_image, ftps
     assert expected_output_file.exists()
 
 
-@pytest.mark.usefixtures("run_containers", "ftps_server")
+@pytest.mark.usefixtures("ftps_server")
 def test_upload_dicom_image_throws(test_zip_content, already_exported_dicom_image) -> None:
     """Tests that exception thrown if DICOM image already exported"""
     # ARRANGE
@@ -51,7 +51,6 @@ def test_upload_dicom_image_throws(test_zip_content, already_exported_dicom_imag
         upload_dicom_image(test_zip_content, pseudo_anon_id)
 
 
-@pytest.mark.usefixtures("run_containers")
 def test_update_exported_and_save(rows_in_session) -> None:
     """Tests that the exported_at field is updated when a file is uploaded"""
     # ARRANGE
@@ -68,7 +67,7 @@ def test_update_exported_and_save(rows_in_session) -> None:
     assert actual_export_time == expected_export_time
 
 
-@pytest.mark.usefixtures("run_containers", "ftps_server")
+@pytest.mark.usefixtures("ftps_server")
 def test_upload_parquet(parquet_export, ftps_home_dir) -> None:
     """Tests that parquet files are uploaded to the correct location"""
     # ARRANGE
@@ -90,7 +89,7 @@ def test_upload_parquet(parquet_export, ftps_home_dir) -> None:
     assert (expected_public_parquet_dir / "radiology.parquet").exists()
 
 
-@pytest.mark.usefixtures("run_containers", "ftps_server")
+@pytest.mark.usefixtures("ftps_server")
 def test_no_export_to_upload(parquet_export) -> None:
     """If there is nothing in the export directly, an exception is thrown"""
     parquet_export.public_output.mkdir(parents=True, exist_ok=True)

--- a/test/scripts/check_ftps_upload.py
+++ b/test/scripts/check_ftps_upload.py
@@ -12,13 +12,10 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
 from pathlib import Path
 from shutil import rmtree
 from time import sleep
 
-OMOP_INPUT_PATH = Path(__file__).parents[1] / "resources" / "omop"
-print(f"parquet path: {OMOP_INPUT_PATH}")
 MOUNTED_DATA_DIR = Path(__file__).parents[1] / "dummy-services" / "ftp-server" / "mounts" / "data"
 print(f"mounted data dir: {MOUNTED_DATA_DIR}")
 
@@ -43,9 +40,11 @@ for seconds in range(0, 121, SECONDS_WAIT):
 
 # We expect 2 DICOM image studies to be uploaded
 assert len(zip_files) == 2
+
+# check the copied files
 assert expected_public_parquet_dir.exists()
-assert (expected_public_parquet_dir / "PROCEDURE_OCCURRENCE.parquet").exists()
-assert (expected_public_parquet_dir / "radiology.parquet").exists()
+assert (expected_public_parquet_dir / "omop" / "public" / "PROCEDURE_OCCURRENCE.parquet").exists()
+assert (expected_public_parquet_dir / "radiology" / "radiology.parquet").exists()
 
 # Clean up; only happens if the assertion passes
 rmtree(expected_output_dir, ignore_errors=True)


### PR DESCRIPTION
(This code is derived from the useful bits of #274 most of which is not needed due to a requirements change)
To make FTP upload code more robust against future changes to the file layout simply upload everything as found, with no assumptions as to layout.
Document the files present at each step of the pipeline.