### PR TITLE
Experimenting with Pkl for the config template

### DIFF
--- a/config-template/PixlConfig.pkl
+++ b/config-template/PixlConfig.pkl
@@ -1,0 +1,22 @@
+module PixlConfig
+
+project: String
+
+class DicomAnonProfile {
+    base_profile: String // TODO: should this be a file path?
+    extension_profile: String? // optional
+}
+
+dicom_anon_profile: DicomAnonProfile
+
+// Permitted values for the destination types
+typealias DicomDestinationType = "FTPS"|"Azure"|"DicomWeb"
+typealias ParquetDestinationType = "FTPS"|"Azure"
+
+class DestinationTypes {
+    // optional, if not set, no upload will be performed for the given file type
+    dicom: DicomDestinationType?
+    parquet: ParquetDestinationType?
+}
+
+destination: DestinationTypes

--- a/config-template/README.md
+++ b/config-template/README.md
@@ -1,0 +1,46 @@
+# Configuration template
+
+>[!WARNING]
+> WORK IN PROGRESS
+
+The PIXL project configuration template is written in [Pkl](https://pkl-lang.org/index.html) to
+allow safe type checking and easy configuration.
+
+## Installation
+
+Follow the [Pkl installation instructions](https://pkl-lang.org/main/current/pkl-cli/index.html#installation)
+for your platform.
+
+## Usage
+
+The `PixlConfig.pkl` file defines the configuration template for a PIXL project. For a new project,
+create a new `.pkl` file and fill out the template like so:
+
+```pkl
+// my_project.pkl
+amends "PixlConfig.pkl"
+
+project = "My Project"
+dicom_anon_profile {
+    base_profile = "???"
+    // extension_profile = "???" // optional
+}
+destination {
+    dicom = "FTPS" // or None, Azure, DicomWeb
+    parquet = "FTPS" // or Azure
+}
+```
+
+Then, run the `pkl` CLI command to check the configuration:
+
+```sh
+pkl eval my_project.pkl
+```
+
+To generate the config in YAML format, run:
+
+```sh
+pkl eval -f yaml my_project.pkl >> my_project.yml
+```
+
+An example can be found in `example.pkl`.

--- a/config-template/example.pkl
+++ b/config-template/example.pkl
@@ -1,0 +1,11 @@
+amends "PixlConfig.pkl"
+
+project = "My Project"
+dicom_anon_profile {
+    base_profile = "???"
+    // extension_profile = "???" // optional
+}
+destination {
+    dicom = "FTPS" // or None, Azure, DicomWeb
+    parquet = "FTPS" // or Azure
+}


### PR DESCRIPTION
Learned how to `Pkl` config files and gave it a try to support our config template.
Still very rough at this point obviously, maybe `Pkl` is a bit overkill.
I'd say the main advantage is the straightforward Type Annotation, and restricting the permitted values for a given field. 

Happy to look for other solutions though if people are not convinced 🙂 

Related to #232 
