### PR TITLE
Try build cache on passing imaging api tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -166,31 +166,6 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3
-
-      - uses: docker/setup-buildx-action@v3
-      # pre-build and cache the postgres container as installing python3 takes a while, doesn't push
-      - name: Cache Docker layers
-        uses: actions/cache@v3
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-      - uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: docker/orthanc-anon/Dockerfile
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
-      - # Temp fix
-        # https://github.com/docker/build-push-action/issues/252
-        # https://github.com/moby/buildkit/issues/1896
-        name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
-
-
       - name: Init Python
         uses: actions/setup-python@v4
         with:
@@ -213,14 +188,15 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: docker/setup-buildx-action@v3
-      # pre-build and cache the orthanc-anon image as installing python3 takes a while, doesn't push
+      # pre-build and cache the postgres container as installing python3 takes a while, doesn't push
       - name: Cache Docker layers
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
+          save-always: true
       - uses: docker/build-push-action@v5
         with:
           context: .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -188,7 +188,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: docker/setup-buildx-action@v3
-      # pre-build and cache the postgres container as installing python3 takes a while, doesn't push
+      # pre-build and cache the orthanc-anon image: installing python3 takes a while, doesn't push
       - name: Cache Docker layers
         uses: actions/cache@v4
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -146,30 +146,6 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
-
-      - uses: docker/setup-buildx-action@v3
-      # pre-build and cache the postgres container as installing python3 takes a while, doesn't push
-      - name: Cache Docker layers
-        uses: actions/cache@v3
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-      - uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: docker/postgres/Dockerfile
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
-      - # Temp fix
-        # https://github.com/docker/build-push-action/issues/252
-        # https://github.com/moby/buildkit/issues/1896
-        name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
-
       - name: Init Python
         uses: actions/setup-python@v4
         with:
@@ -190,6 +166,30 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3
+
+      - uses: docker/setup-buildx-action@v3
+      # pre-build and cache the postgres container as installing python3 takes a while, doesn't push
+      - name: Cache Docker layers
+        uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      - uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: docker/orthanc-anon/Dockerfile
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+      - # Temp fix
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+        name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+
 
       - name: Init Python
         uses: actions/setup-python@v4

--- a/pytest-pixl/src/pytest_pixl/ftpserver.py
+++ b/pytest-pixl/src/pytest_pixl/ftpserver.py
@@ -129,6 +129,6 @@ class PixlFTPServer:
         method.
         """
         address = (self.host, self.port)
-        print(f"Starting FTP server on {self.host}:{self.port}")
+        logger.info("Starting FTP server on %s:%d", self.host, self.port)
         self.server = ThreadedFTPServer(address, self.handler)
         return self.server


### PR DESCRIPTION
Default behaviour of github caching action is to not save to save if the workflow fails.

On passing test:
first run with caching enabled: [8m35s for entire imaging-api action](https://github.com/UCLH-Foundry/PIXL/actions/runs/7986327198?pr=313)
second run with caching enabled: [4m25s for entire imaging-api action](https://github.com/UCLH-Foundry/PIXL/actions/runs/7986432516?pr=313)

Updated the github caching action to always save cache