### PR TITLE
Correct instructions for editable installs

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -25,7 +25,7 @@ management tool such as [conda](https://docs.conda.io/en/latest/) or
 Then install in editable mode by running
 
 ```bash
-pip install -e ../pixl_core/ .
+pip install -e ../pixl_core/ -e .
 ```
 
 ## Usage
@@ -108,7 +108,7 @@ Commands:
 Install locally in editable mode with the development and testing dependencies by running
 
 ```bash
-pip install -e ../pixl_core/ .[test]
+pip install -e ../pixl_core/ -e .[test]
 ```
 
 ### Running tests

--- a/pixl_core/README.md
+++ b/pixl_core/README.md
@@ -24,7 +24,7 @@ pip install -e .
 ## Testing
 
 ```bash
-pip install -e .[test] && pip install ../pytest-pixl
+pip install -e .[test] && pip install -e ../pytest-pixl
 pytest
 ```
 

--- a/pixl_dcmd/README.md
+++ b/pixl_dcmd/README.md
@@ -20,7 +20,7 @@ Specifically, the `pixl_dcmd` package provides the following functionality:
 Install the Python dependencies with
 
 ```bash
-pip install -e ../pixl_core/ .[test,dev]
+pip install -e ../pixl_core/ -e .[test,dev]
 ```
 
 ## Test

--- a/pixl_ehr/README.md
+++ b/pixl_ehr/README.md
@@ -27,13 +27,13 @@ On Windows, follow [these instructions](https://www.postgresqltutorial.com/postg
 Then install the Python dependencies with
 
 ```bash
-pip install -e ../pixl_core/ .
+pip install -e ../pixl_core/ -e .
 ```
 
 ## Test
 
 ```bash
-pip install -e ../pixl_core/ .[test]
+pip install -e ../pixl_core/ -e .[test]
 pytest -m "not processing"
 ```
 

--- a/pixl_imaging/README.md
+++ b/pixl_imaging/README.md
@@ -12,7 +12,7 @@ for the requested imaging study, if it didn't already exist.
 ## Installation
 
 ```bash
-pip install -e ../pixl_core/ .
+pip install -e ../pixl_core/ -e .
 ```
 
 ## Test


### PR DESCRIPTION
We previously assumed `pip install -e` installed all following packages in editable mode, which is wrong.

### Old
```
pip install -e ../pixl_core .
```

which would copy the local package to the virtual environment, see pip freeze extract 

```
pixl_ehr @ file:///Users/petertsrunchev/Repositories/PIXL/PIXL/pixl_ehr
```
### New

```
pip install -e ../pixl_core -e .
```

which correctly installs local package as editable. 

Pip freeze:
```
-e git+ssh://git@github.com/UCLH-Foundry/PIXL.git@9c6f5a62fca5296d91cb4c93f647b9f037818086#egg=pixl_ehr&subdirectory=pixl_ehr
```

This updates the docs to reflect the correct way of installing editable packages.