### PR TITLE
Increase http timeouts because export radiology + parquet upload is performed synchronously

### DIFF
--- a/cli/src/pixl_cli/main.py
+++ b/cli/src/pixl_cli/main.py
@@ -120,7 +120,7 @@ def extract_radiology_reports(parquet_dir: Path) -> None:
     response = requests.post(
         url=f"{api_config.base_url}/export-patient-data",
         json={"project_name": project_name, "extract_datetime": omop_es_datetime.isoformat()},
-        timeout=10,
+        timeout=300,
     )
 
     success_code = 200

--- a/orthanc/orthanc-anon/plugin/pixl.py
+++ b/orthanc/orthanc-anon/plugin/pixl.py
@@ -153,7 +153,7 @@ def SendViaStow(resourceId):
             auth=(ORTHANC_USERNAME, ORTHANC_PASSWORD),
             headers=headers,
             data=json.dumps(payload),
-            timeout=10,
+            timeout=30,
         )
         msg = f"Sent {resourceId} via STOW"
         logger.info(msg)


### PR DESCRIPTION
The API call to export_patient_data is synchronous. Ie. it has to export the radiology parquet file, and upload all parquet files to FTP before returning via HTTP to the CLI.

Therefore the 10 second timeout on the client side is probably way too short.

I have increased it by a lot here - but the server or something in between may still cause a timeout. If so, we may have to look into sending TCP keepalives. I also increased the orthanc upload by a bit but wasn't sure if that was for a single image or something more.

What’s the biggest set of data this call has been tested with so far? I may be way overestimating how long it takes.

Synchronously waiting for some potentially unreliable tasks (eg FTP upload) to happen is probably not a great design for a distributed system like we have, but that’s a wider problem that should receive separate discussion.