### PR TITLE
Update to latest orthanc containers with Python 3.11

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Init Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
           cache: "pip"
 
       - name: Install package
@@ -77,7 +77,7 @@ jobs:
       - name: Init Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
           cache: "pip"
 
       - name: Install Python dependencies
@@ -100,7 +100,7 @@ jobs:
       - name: Init Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "3.11"
           cache: "pip"
 
       - name: Install Python dependencies
@@ -126,7 +126,7 @@ jobs:
       - name: Init Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
           cache: "pip"
 
       - name: Install Python dependencies
@@ -148,7 +148,7 @@ jobs:
       - name: Init Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.10.6
+          python-version: "3.11"
           cache: "pip"
 
       - name: Install Python dependencies
@@ -168,7 +168,7 @@ jobs:
       - name: Init Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.10.6
+          python-version: "3.11"
           cache: "pip"
 
       - name: Install Python dependencies
@@ -214,7 +214,7 @@ jobs:
       - name: Init Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.10.6
+          python-version: "3.11"
           cache: "pip"
 
       - name: Install Python dependencies

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -164,7 +164,7 @@ services:
     healthcheck:
       test: 
         [
-          "CMD-SHELL", "/probes/test-aliveness.py --user=${ORTHANC_RAW_USERNAME} --pwd=${ORTHANC_RAW_PASSWORD}"
+          "CMD-SHELL", "/probes/test-aliveness.py --user=$ORTHANC_USERNAME --pwd=$ORTHANC_PASSWORD"
         ]
       start_period: 10s
       retries: 2
@@ -216,7 +216,7 @@ services:
     healthcheck:
       test: 
         [
-          "CMD-SHELL", "/probes/test-aliveness.py --user=${ORTHANC_RAW_USERNAME} --pwd=${ORTHANC_RAW_PASSWORD}"
+          "CMD-SHELL", "/probes/test-aliveness.py --user=$ORTHANC_USERNAME --pwd=$ORTHANC_PASSWORD"
         ]
       start_period: 10s
       retries: 2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -113,6 +113,7 @@ services:
       dockerfile: ./docker/orthanc-anon/Dockerfile
       args:
         <<: *build-args-common
+    platform: linux/amd64
     command: /run/secrets
     environment:
       <<: [*proxy-common, *pixl-common-env, *azure-keyvault]
@@ -161,18 +162,14 @@ services:
       postgres:
         condition: service_healthy
     healthcheck:
-      test:
+      test: 
         [
-          "CMD",
-          "curl",
-          "-f",
-          "-u",
-          "${ORTHANC_ANON_USERNAME}:${ORTHANC_ANON_PASSWORD}",
-          "http://orthanc-anon:8042/heart-beat",
+          "CMD-SHELL", "/probes/test-aliveness.py --user=${ORTHANC_RAW_USERNAME} --pwd=${ORTHANC_RAW_PASSWORD}"
         ]
-      interval: 10s
-      timeout: 30s
-      retries: 5
+      start_period: 10s
+      retries: 2
+      interval: 3s
+      timeout: 2s
     restart: "no"
 
   orthanc-raw:
@@ -182,6 +179,7 @@ services:
       args:
         <<: *build-args-common
         ORTHANC_RAW_MAXIMUM_STORAGE_SIZE: ${ORTHANC_RAW_MAXIMUM_STORAGE_SIZE}
+    platform: linux/amd64
     command: /run/secrets
     environment:
       <<: [*pixl-db, *proxy-common, *pixl-common-env]
@@ -216,18 +214,14 @@ services:
       orthanc-anon:
         condition: service_started
     healthcheck:
-      test:
+      test: 
         [
-          "CMD",
-          "curl",
-          "-f",
-          "-u",
-          "${ORTHANC_RAW_USERNAME}:${ORTHANC_RAW_PASSWORD}",
-          "http://orthanc-raw:8042/heart-beat",
+          "CMD-SHELL", "/probes/test-aliveness.py --user=${ORTHANC_RAW_USERNAME} --pwd=${ORTHANC_RAW_PASSWORD}"
         ]
-      interval: 10s
-      timeout: 30s
-      retries: 5
+      start_period: 10s
+      retries: 2
+      interval: 3s
+      timeout: 2s
     restart: "no"
 
   queue:

--- a/docker/orthanc-anon/Dockerfile
+++ b/docker/orthanc-anon/Dockerfile
@@ -14,18 +14,19 @@
 FROM orthancteam/orthanc:24.3.3
 SHELL ["/bin/bash", "-o", "pipefail", "-e", "-u", "-x", "-c"]
 # Install requirements before copying modules
-COPY ./pixl_core/pyproject.toml ./pixl_core/pyproject.toml
-COPY ./pixl_dcmd/pyproject.toml ./pixl_dcmd/pyproject.toml
+COPY ./pixl_core/pyproject.toml /pixl_core/pyproject.toml
+COPY ./pixl_dcmd/pyproject.toml /pixl_dcmd/pyproject.toml
+
 RUN --mount=type=cache,target=/root/.cache \
     pip3 install pixl_core/ \
     && pip3 install pixl_dcmd/
 
 COPY ./orthanc/orthanc-anon/plugin/pixl.py /etc/orthanc/pixl.py
 
-COPY ./pixl_core/ ./pixl_core
+COPY ./pixl_core/ /pixl_core
 RUN --mount=type=cache,target=/root/.cache \
     pip3 install ./pixl_core
 
-COPY ./pixl_dcmd/ ./pixl_dcmd
+COPY ./pixl_dcmd/ /pixl_dcmd
 RUN --mount=type=cache,target=/root/.cache \
     pip3 install ./pixl_dcmd

--- a/docker/orthanc-anon/Dockerfile
+++ b/docker/orthanc-anon/Dockerfile
@@ -11,42 +11,8 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-FROM osimis/orthanc:22.9.0-full-stable
+FROM orthancteam/orthanc:24.3.3
 SHELL ["/bin/bash", "-o", "pipefail", "-e", "-u", "-x", "-c"]
-# need some packages for building python 3.9.13
-RUN export DEBIAN_FRONTEND=noninteractive \
-    && apt update \
-    && apt install --yes --no-install-recommends \
-           build-essential \
-           libbz2-dev \
-           libffi-dev \
-           libgdbm-dev \
-           libncurses5-dev \
-           libnss3-dev \
-           libreadline-dev \
-           libsqlite3-dev \
-           libssl-dev \
-           zlib1g-dev \
-    && apt-get autoremove \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-
-# Default for Debian Bullseye (11) is python 3.9.2, which has a bug in ftplib that is
-# affecting us.
-# See https://bugs.python.org/issue43285 for more details. It only happens in the system
-# test, when docker is using NAT to implement host.docker.internal
-# Install 3.9.13 alongside the existing version (removing the original python beforehand
-# seems to break orthanc)
-ADD https://www.python.org/ftp/python/3.9.13/Python-3.9.13.tgz /python3913/
-RUN cd /python3913 \
-    && tar -xvf Python-3.9.13.tgz \
-    && cd Python-3.9.13 \
-    && ./configure --enable-optimizations \
-    && make -j `nproc` \
-    && make install \
-    && make clean \
-    && rm -fr /python3913
-
 # Install requirements before copying modules
 COPY ./pixl_core/pyproject.toml ./pixl_core/pyproject.toml
 COPY ./pixl_dcmd/pyproject.toml ./pixl_dcmd/pyproject.toml

--- a/docker/orthanc-anon/Dockerfile
+++ b/docker/orthanc-anon/Dockerfile
@@ -13,20 +13,31 @@
 #  limitations under the License.
 FROM orthancteam/orthanc:24.3.3
 SHELL ["/bin/bash", "-o", "pipefail", "-e", "-u", "-x", "-c"]
+
+# Create a virtual environment, recommended since python 3.11 and Debian bookworm based images
+# where you get a warning when installing system-wide packages.
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt-get update && \
+    apt-get install --yes --no-install-recommends python3-venv
+RUN python3 -m venv /.venv
+
 # Install requirements before copying modules
 COPY ./pixl_core/pyproject.toml /pixl_core/pyproject.toml
 COPY ./pixl_dcmd/pyproject.toml /pixl_dcmd/pyproject.toml
 
 RUN --mount=type=cache,target=/root/.cache \
-    pip3 install pixl_core/ \
-    && pip3 install pixl_dcmd/
+    /.venv/bin/pip install pixl_core/ \
+    && /.venv/bin/pip install pixl_dcmd/
 
 COPY ./orthanc/orthanc-anon/plugin/pixl.py /etc/orthanc/pixl.py
 
 COPY ./pixl_core/ /pixl_core
 RUN --mount=type=cache,target=/root/.cache \
-    pip3 install ./pixl_core
+    /.venv/bin/pip install ./pixl_core
 
 COPY ./pixl_dcmd/ /pixl_dcmd
 RUN --mount=type=cache,target=/root/.cache \
-    pip3 install ./pixl_dcmd
+    /.venv/bin/pip install ./pixl_dcmd
+
+ENV PYTHONPATH=/.venv/lib64/python3.11/site-packages/
+

--- a/docker/orthanc-anon/Dockerfile
+++ b/docker/orthanc-anon/Dockerfile
@@ -21,6 +21,9 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get install --yes --no-install-recommends python3-venv
 RUN python3 -m venv /.venv
 
+# Install curl, used in system tests
+RUN apt-get --assume-yes install curl
+
 # Install requirements before copying modules
 COPY ./pixl_core/pyproject.toml /pixl_core/pyproject.toml
 COPY ./pixl_dcmd/pyproject.toml /pixl_dcmd/pyproject.toml

--- a/docker/orthanc-raw/Dockerfile
+++ b/docker/orthanc-raw/Dockerfile
@@ -11,7 +11,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-FROM osimis/orthanc:22.9.0-full-stable
+FROM orthancteam/orthanc:24.3.3
 SHELL ["/bin/bash", "-o", "pipefail", "-e", "-u", "-x", "-c"]
 
 ARG ORTHANC_RAW_MAXIMUM_STORAGE_SIZE

--- a/docker/orthanc-raw/Dockerfile
+++ b/docker/orthanc-raw/Dockerfile
@@ -16,28 +16,33 @@ SHELL ["/bin/bash", "-o", "pipefail", "-e", "-u", "-x", "-c"]
 
 ARG ORTHANC_RAW_MAXIMUM_STORAGE_SIZE
 
+# Create a virtual environment, recommended since python 3.11 and Debian bookworm based images
+# where you get a warning when installing system-wide packages.
 RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get update && \
     apt-get install --yes --no-install-recommends python3-venv
+RUN python3 -m venv /.venv
 
 # Install requirements before copying modules
 COPY ./pixl_core/pyproject.toml /pixl_core/pyproject.toml
 COPY ./pixl_dcmd/pyproject.toml /pixl_dcmd/pyproject.toml
 
 RUN --mount=type=cache,target=/root/.cache \
-    pip3 install pixl_core/ \
-    && pip3 install pixl_dcmd/
+    /.venv/bin/pip install pixl_core/ \
+    && /.venv/bin/pip install pixl_dcmd/
 
-COPY ./pixl_core/ ./pixl_core
+COPY ./pixl_core/ /pixl_core
 RUN --mount=type=cache,target=/root/.cache \
-    pip3 install ./pixl_core
+    /.venv/bin/pip install ./pixl_core
 
-COPY ./pixl_dcmd/ ./pixl_dcmd
+COPY ./pixl_dcmd/ /pixl_dcmd
 RUN --mount=type=cache,target=/root/.cache \
-    pip3 install ./pixl_dcmd
+    /.venv/bin/pip install ./pixl_dcmd
 
 COPY ./orthanc/orthanc-raw/plugin/pixl.py /etc/orthanc/pixl.py
 
 # Orthanc can't substitute environment veriables as integers so copy and replace before running
 COPY ./orthanc/orthanc-raw/config /run/secrets
 RUN sed -i "s/\${ORTHANC_RAW_MAXIMUM_STORAGE_SIZE}/${ORTHANC_RAW_MAXIMUM_STORAGE_SIZE:-0}/g" /run/secrets/orthanc.json
+
+ENV PYTHONPATH=/.venv/lib64/python3.11/site-packages/

--- a/docker/orthanc-raw/Dockerfile
+++ b/docker/orthanc-raw/Dockerfile
@@ -17,12 +17,13 @@ SHELL ["/bin/bash", "-o", "pipefail", "-e", "-u", "-x", "-c"]
 ARG ORTHANC_RAW_MAXIMUM_STORAGE_SIZE
 
 RUN export DEBIAN_FRONTEND=noninteractive && \
-    apt update && \
-    apt install --yes --no-install-recommends python3-venv
+    apt-get update && \
+    apt-get install --yes --no-install-recommends python3-venv
 
 # Install requirements before copying modules
-COPY ./pixl_core/pyproject.toml ./pixl_core/pyproject.toml
-COPY ./pixl_dcmd/pyproject.toml ./pixl_dcmd/pyproject.toml
+COPY ./pixl_core/pyproject.toml /pixl_core/pyproject.toml
+COPY ./pixl_dcmd/pyproject.toml /pixl_dcmd/pyproject.toml
+
 RUN --mount=type=cache,target=/root/.cache \
     pip3 install pixl_core/ \
     && pip3 install pixl_dcmd/

--- a/pixl_dcmd/pyproject.toml
+++ b/pixl_dcmd/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.0.2"
 authors = [{ name = "PIXL authors" }]
 description = "DICOM header anonymisation functions"
 readme = "README.md"
-requires-python = "~=3.9"
+requires-python = ">=3.11"
 classifiers = ["Programming Language :: Python :: 3"]
 dependencies = [
     "arrow==1.2.3",

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -37,10 +37,15 @@ services:
         volumes:
             - ${PWD}/vna_config/:/run/secrets:ro
         healthcheck:
-            test: ["CMD", "curl", "-f", "-u", "orthanc:orthanc", "http://vna-qr:8042/patients"]
-            interval: 10s
-            timeout: 30s
-            retries: 5
+            test:
+                [
+                    "CMD-SHELL",
+                    "/probes/test-aliveness.py --user=orthanc, --pwd=orthanc",
+                ]
+            start_period: 10s
+            retries: 2
+            interval: 3s
+            timeout: 2s
         networks:
             pixl-net:
 

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -21,7 +21,8 @@ networks:
 
 services:
     vna-qr:
-        image: osimis/orthanc:22.9.0-full-stable
+        image: orthancteam/orthanc:24.3.3
+        platform: linux/amd64
         environment:
             ORTHANC_NAME: ${VNAQR_AE_TITLE}
             ORTHANC_USERNAME: "orthanc"

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -40,7 +40,7 @@ services:
             test:
                 [
                     "CMD-SHELL",
-                    "/probes/test-aliveness.py --user=orthanc, --pwd=orthanc",
+                    "/probes/test-aliveness.py --user=orthanc --pwd=orthanc",
                 ]
             start_period: 10s
             retries: 2


### PR DESCRIPTION
Using the new `orthancteam/orthanc` images, following their [update to Debian 12](https://github.com/orthanc-server/orthanc-builder/blob/master/release-notes-docker-images.md#2433).
This should allow us to use Python 3.11 everywhere.
