### PR TITLE
Fix ruff in `precommit`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@
 ---
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.6
+    rev: v0.3.3
     hooks:
       - id: ruff-format
       - id: ruff

--- a/bin/pixldc
+++ b/bin/pixldc
@@ -13,6 +13,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 """A wrapper around docker compose that sets the correct directory and environment"""
+
 import argparse
 import logging
 import os

--- a/cli/src/pixl_cli/__init__.py
+++ b/cli/src/pixl_cli/__init__.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 """PIXL command line interface"""
+
 from __future__ import annotations
 
 from pixl_cli.main import cli

--- a/cli/src/pixl_cli/main.py
+++ b/cli/src/pixl_cli/main.py
@@ -72,7 +72,7 @@ def check_env(*, error: bool, sample_env_file: click.Path) -> None:
     for key in sample_config.data:
         try:
             config(key)
-        except UndefinedValueError:  # noqa: PERF203
+        except UndefinedValueError:
             logger.warning("Environment variable %s is not set", key)
             if error:
                 raise

--- a/cli/src/pixl_cli/main.py
+++ b/cli/src/pixl_cli/main.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 """PIXL command line interface functionality"""
+
 from __future__ import annotations
 
 import json

--- a/cli/tests/conftest.py
+++ b/cli/tests/conftest.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 """CLI testing fixtures."""
+
 from __future__ import annotations
 
 import os

--- a/cli/tests/test_check_env.py
+++ b/cli/tests/test_check_env.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 """Tests for check_env function of CLI."""
+
 from pathlib import Path
 
 from click.testing import CliRunner

--- a/cli/tests/test_database.py
+++ b/cli/tests/test_database.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 
 """Test database interaction methods for the cli."""
+
 import datetime
 
 import pytest

--- a/cli/tests/test_io.py
+++ b/cli/tests/test_io.py
@@ -14,7 +14,6 @@
 
 """Test functions in _io.py."""
 
-
 import pytest
 from pixl_cli._io import messages_from_csv
 

--- a/cli/tests/test_messages_from_parquet.py
+++ b/cli/tests/test_messages_from_parquet.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 """Unit tests for reading cohorts from parquet files."""
+
 from __future__ import annotations
 
 import datetime

--- a/cli/tests/test_populate.py
+++ b/cli/tests/test_populate.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 """Patient queue tests"""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/hasher/pyproject.toml
+++ b/hasher/pyproject.toml
@@ -38,6 +38,6 @@ build-backend = "setuptools.build_meta"
 [tool.ruff]
 extend = "../ruff.toml"
 
-[tool.ruff.extend-per-file-ignores]
+[tool.ruff.lint.extend-per-file-ignores]
 "./tests/**" = ["D1"]
 "./src/hasher/endpoints.py" = ["D103"]

--- a/hasher/src/hasher/__init__.py
+++ b/hasher/src/hasher/__init__.py
@@ -21,6 +21,7 @@ The key is stored as a secret in an Azure Key Vault.
 The Azure infrastructure (Key Vault, ServicePrincipal & permissions) must be persistent
 and instructions are provided for creating these with the az CLI tool.
 """
+
 from __future__ import annotations
 
 import importlib.metadata

--- a/hasher/src/hasher/endpoints.py
+++ b/hasher/src/hasher/endpoints.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 """Sets up endpoints for the hasher-api"""
+
 from __future__ import annotations
 
 from fastapi import APIRouter

--- a/hasher/src/hasher/hashing.py
+++ b/hasher/src/hasher/hashing.py
@@ -20,6 +20,7 @@ This module provides:
 - generate_salt: generate a random text string in hexadecimal to be used as a salt
 
 """
+
 from __future__ import annotations
 
 import logging

--- a/hasher/src/hasher/main.py
+++ b/hasher/src/hasher/main.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 """Defines the FastAPI app for the hasher"""
+
 from __future__ import annotations
 
 import logging

--- a/hasher/src/hasher/settings.py
+++ b/hasher/src/hasher/settings.py
@@ -22,6 +22,7 @@ The following settings are defined:
 - "AZURE_KEY_VAULT_NAME"
 - "AZURE_KEY_VAULT_SECRET_NAME"
 """
+
 from __future__ import annotations
 
 import pprint

--- a/orthanc/orthanc-anon/plugin/pixl.py
+++ b/orthanc/orthanc-anon/plugin/pixl.py
@@ -18,6 +18,7 @@ This module:
 -Modifies a DICOM instance received by Orthanc and applies anonymisation
 -Upload the resource to a dicom-web server
 """
+
 from __future__ import annotations
 
 import json

--- a/orthanc/orthanc-raw/plugin/pixl.py
+++ b/orthanc/orthanc-raw/plugin/pixl.py
@@ -19,6 +19,7 @@ This module provides:
 -should_auto_route: checks whether auto-routing is enabled
 -OnHeartBeat: extends the REST API
 """
+
 from __future__ import annotations
 
 import os

--- a/pixl_core/pyproject.toml
+++ b/pixl_core/pyproject.toml
@@ -45,9 +45,9 @@ markers = ["pika"]
 [tool.ruff]
 extend = "../ruff.toml"
 
-[tool.ruff.extend-per-file-ignores]
+[tool.ruff.lint.extend-per-file-ignores]
 "./tests/**" = ["D100"]
 
-[tool.ruff.pep8-naming]
+[tool.ruff.lint.pep8-naming]
 # Allow Pydantic's `@field_validator` decorator to trigger class method treatment.
 classmethod-decorators = ["classmethod", "pydantic.field_validator"]

--- a/pixl_core/src/core/__init__.py
+++ b/pixl_core/src/core/__init__.py
@@ -17,4 +17,5 @@ This module contains the core PIXL functionality utilised by both the EHR and Im
 to interact with RabbitMQ and ensure suitable rate limiting of requests to the upstream
 services.
 """
+
 from __future__ import annotations

--- a/pixl_core/src/core/db/models.py
+++ b/pixl_core/src/core/db/models.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 
 """Interaction with PIXL database"""
+
 from __future__ import annotations
 
 from typing import Optional

--- a/pixl_core/src/core/dicom_tags.py
+++ b/pixl_core/src/core/dicom_tags.py
@@ -20,6 +20,7 @@ This information is currently duplicated in
 
 For now you will have to manually keep these in step.
 """
+
 from dataclasses import dataclass
 
 

--- a/pixl_core/src/core/exports.py
+++ b/pixl_core/src/core/exports.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 """Processing of OMOP parquet files."""
+
 from __future__ import annotations
 
 import logging

--- a/pixl_core/src/core/patient_queue/__init__.py
+++ b/pixl_core/src/core/patient_queue/__init__.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 """RabbitMQ consumer for Pixl"""
+
 from __future__ import annotations
 
 from .subscriber import PixlConsumer

--- a/pixl_core/src/core/patient_queue/message.py
+++ b/pixl_core/src/core/patient_queue/message.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 """Classes to represent messages in the patient queue."""
+
 from __future__ import annotations
 
 import logging

--- a/pixl_core/src/core/patient_queue/producer.py
+++ b/pixl_core/src/core/patient_queue/producer.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 """Producer for RabbitMQ"""
+
 from __future__ import annotations
 
 import logging

--- a/pixl_core/src/core/project_config.py
+++ b/pixl_core/src/core/project_config.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 
 """Project-specific configuration for Pixl."""
+
 from __future__ import annotations
 
 import logging

--- a/pixl_core/src/core/rest_api/router.py
+++ b/pixl_core/src/core/rest_api/router.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 """Router for the API endpoints"""
+
 from __future__ import annotations
 
 from fastapi import APIRouter, HTTPException, status

--- a/pixl_core/src/core/token_buffer/__init__.py
+++ b/pixl_core/src/core/token_buffer/__init__.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 """Implements the TokenBucket class"""
+
 from __future__ import annotations
 
 from .tokens import TokenBucket

--- a/pixl_core/src/core/token_buffer/models.py
+++ b/pixl_core/src/core/token_buffer/models.py
@@ -15,6 +15,7 @@
 PIXL core models
 This module defines the data models used by the PIXL core service
 """
+
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/pixl_core/tests/test_exports.py
+++ b/pixl_core/tests/test_exports.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 """Test copying of OMOP ES data for later export."""
+
 from __future__ import annotations
 
 import datetime

--- a/pixl_core/tests/uploader/test_ftps.py
+++ b/pixl_core/tests/uploader/test_ftps.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 """Test functionality to upload files to an endpoint."""
+
 import filecmp
 import pathlib
 from datetime import datetime, timezone

--- a/pixl_dcmd/pyproject.toml
+++ b/pixl_dcmd/pyproject.toml
@@ -35,7 +35,7 @@ build-backend = "setuptools.build_meta"
 [tool.ruff]
 extend = "./ruff.toml"
 
-[tool.ruff.extend-per-file-ignores]
+[tool.ruff.lint.extend-per-file-ignores]
 "./tests/**" = ["D100"]
 
 [tool.setuptools.package-data]

--- a/pixl_dcmd/ruff.toml
+++ b/pixl_dcmd/ruff.toml
@@ -1,2 +1,2 @@
-[extend-per-file-ignores]
+[lint.extend-per-file-ignores]
 "src/pixl_dcmd/main.py" = ["PLR2004", "PLR0912", "PLR0915"] #  Magic value used in comparison, Too many branches, Too many statements

--- a/pixl_dcmd/src/pixl_dcmd/_database.py
+++ b/pixl_dcmd/src/pixl_dcmd/_database.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 
 """Interaction with the PIXL database."""
+
 from decouple import config
 
 from core.db.models import Image

--- a/pixl_dcmd/src/pixl_dcmd/_datetime.py
+++ b/pixl_dcmd/src/pixl_dcmd/_datetime.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 
 """Datetime helper functions."""
+
 import logging
 from random import randint
 from typing import Any

--- a/pixl_dcmd/src/pixl_dcmd/_deid_helpers.py
+++ b/pixl_dcmd/src/pixl_dcmd/_deid_helpers.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 """Helper functions for de-identification."""
+
 import hashlib
 import re
 

--- a/pixl_dcmd/tests/conftest.py
+++ b/pixl_dcmd/tests/conftest.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 """CLI testing fixtures."""
+
 from __future__ import annotations
 import datetime
 import os

--- a/pixl_dcmd/tests/test_datetime.py
+++ b/pixl_dcmd/tests/test_datetime.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 
 """Test datetime helpers."""
+
 import pytest
 
 from pixl_dcmd._datetime import combine_date_time, format_date_time

--- a/pixl_dcmd/tests/test_deid_helpers.py
+++ b/pixl_dcmd/tests/test_deid_helpers.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 
 """Tests for anonymisation of DICOM data."""
+
 import pytest
 
 from pixl_dcmd._deid_helpers import get_bounded_age, get_encrypted_uid

--- a/pixl_ehr/pyproject.toml
+++ b/pixl_ehr/pyproject.toml
@@ -39,7 +39,7 @@ markers = ["processing"]
 [tool.ruff]
 extend = "../ruff.toml"
 
-[tool.ruff.extend-per-file-ignores]
+[tool.ruff.lint.extend-per-file-ignores]
 "./tests/**" = ["D1"]
 
 [tool.setuptools.package-data]

--- a/pixl_ehr/src/pixl_ehr/main.py
+++ b/pixl_ehr/src/pixl_ehr/main.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 """pixl_ehr module is an EHR extraction service app"""
+
 from __future__ import annotations
 
 import asyncio

--- a/pixl_ehr/src/pixl_ehr/main.py
+++ b/pixl_ehr/src/pixl_ehr/main.py
@@ -156,7 +156,7 @@ async def az_copy_current(csv_filename: str = "extract.csv") -> None:
         csv_filename,
     )
 
-    with Path(file=csv_filename, mode="rb").open() as data:
+    with Path(file=csv_filename, mode="rb").open() as data:  # noqa: ASYNC101
         blob_client.upload_blob(data)
 
     logger.info("Uploaded successfully!")

--- a/pixl_ehr/src/pixl_ehr/report_deid/__init__.py
+++ b/pixl_ehr/src/pixl_ehr/report_deid/__init__.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 """Deidentifaction of text"""
+
 from __future__ import annotations
 
 from .deid import deidentify_text

--- a/pixl_ehr/src/pixl_ehr/report_deid/deid.py
+++ b/pixl_ehr/src/pixl_ehr/report_deid/deid.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 """Collection of functions for deidentifaction of text"""
+
 from __future__ import annotations
 
 import os

--- a/pixl_ehr/tests/test_app.py
+++ b/pixl_ehr/tests/test_app.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 """This file contains unit tests for the API that do not require any test services"""
+
 from __future__ import annotations
 
 from fastapi.testclient import TestClient

--- a/pixl_ehr/tests/test_processing.py
+++ b/pixl_ehr/tests/test_processing.py
@@ -38,7 +38,7 @@ from psycopg2.errors import UniqueViolation
 
 pytest_plugins = ("pytest_asyncio",)
 
-logger = getLogger(__file__)
+logger = getLogger(__name__)
 
 
 @dataclasses.dataclass

--- a/pixl_ehr/tests/test_processing.py
+++ b/pixl_ehr/tests/test_processing.py
@@ -17,6 +17,7 @@ services being up
     - pixl postgres db
     - emap star
 """
+
 from __future__ import annotations
 
 import contextlib

--- a/pixl_imaging/alembic/env.py
+++ b/pixl_imaging/alembic/env.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 """Alembic configuration"""
+
 from logging.config import fileConfig
 
 from decouple import Config, RepositoryEnv

--- a/pixl_imaging/alembic/versions/bcaef54e2bfe_create_extract_and_image_tables.py
+++ b/pixl_imaging/alembic/versions/bcaef54e2bfe_create_extract_and_image_tables.py
@@ -18,6 +18,7 @@ Revises:
 Create Date: 2024-02-12 14:43:36.716242
 
 """
+
 from collections.abc import Sequence
 from typing import Union
 

--- a/pixl_imaging/pyproject.toml
+++ b/pixl_imaging/pyproject.toml
@@ -38,7 +38,7 @@ markers = ["processing"]
 [tool.ruff]
 extend = "../ruff.toml"
 
-[tool.ruff.extend-per-file-ignores]
+[tool.ruff.lint.extend-per-file-ignores]
 "./tests/**" = ["D1"]
 "./alembic/**" = [
     "INP001",  # is part of an implicit namespace package. Add an `__init__.py`

--- a/pixl_imaging/src/pixl_imaging/main.py
+++ b/pixl_imaging/src/pixl_imaging/main.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 """pixl_imaging module queries the VNA to check if a dataset exists"""
+
 from __future__ import annotations
 
 import asyncio

--- a/pixl_imaging/tests/test_processing.py
+++ b/pixl_imaging/tests/test_processing.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 """These tests require docker containers to be up to be able to run."""
+
 from __future__ import annotations
 
 import datetime

--- a/pytest-pixl/pyproject.toml
+++ b/pytest-pixl/pyproject.toml
@@ -39,7 +39,7 @@ pytest_pixl = ["*.key", "*.crt"]
 [tool.ruff]
 extend = "../ruff.toml"
 
-[tool.ruff.extend-per-file-ignores]
+[tool.ruff.lint.extend-per-file-ignores]
 "./tests/**" = ["D100"]
 
 [project.entry-points.pytest11]

--- a/pytest-pixl/src/pytest_pixl/ftpserver.py
+++ b/pytest-pixl/src/pytest_pixl/ftpserver.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 """A ligthweight FTPS server supporting implicit SSL for use in PIXL tests."""
+
 import logging
 from pathlib import Path
 

--- a/pytest-pixl/src/pytest_pixl/helpers.py
+++ b/pytest-pixl/src/pytest_pixl/helpers.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 """Testing utilities"""
+
 from __future__ import annotations
 
 import logging

--- a/ruff.toml
+++ b/ruff.toml
@@ -2,7 +2,7 @@ line-length = 100
 fix = true
 force-exclude = true
 namespace-packages = ["orthanc/orthanc-anon/plugin", "orthanc/orthanc-raw/plugin"]
-ignore = [
+lint.ignore = [
     "ANN001", # missing type function argument
     "ANN003", # missing type annotation **
     "ANN101", # missng type annotation for `self`
@@ -30,7 +30,7 @@ ignore = [
     "TD004",  # missing colon in #TODO
     "S608",   # possible SQL injection vectors (#FIXME)
 ]
-per-file-ignores = {"*test*" = [
+lint.per-file-ignores = {"*test*" = [
     "ARG001", # Unused function argument, fixtures can be used for their side effects
     "INP001",
     "S101",
@@ -40,14 +40,14 @@ per-file-ignores = {"*test*" = [
 ], "postgres/*" = [
     "INP001",
 ]}
-select = [
+lint.select = [
     "ALL",
 ]
-target-version = "py310"
-mccabe.max-complexity = 18
+target-version = "py311"
+lint.mccabe.max-complexity = 18
 exclude=["scripts"]
 
-[extend-per-file-ignores]
+[lint.extend-per-file-ignores]
 "**/test*/*" = ["PLR2004"] #  Magic value used in comparison
 "hasher/tests/*" = ["ARG001"] #  unused function argument
 "env.py" = ["INP001", "E402", "ERA001"]

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 """System/E2E test setup"""
+
 from pathlib import Path
 
 import pytest

--- a/test/dummy-services/cogstack/cogstack.py
+++ b/test/dummy-services/cogstack/cogstack.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 """Fake cogstack service for system testing"""
+
 from __future__ import annotations
 
 import asyncio

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 """Replacement for the 'interesting' bits of the system/E2E test"""
+
 import logging
 from pathlib import Path
 

--- a/test/test_parquet_exports.py
+++ b/test/test_parquet_exports.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 """Check validity of radiology export"""
+
 import logging
 from pathlib import Path
 

--- a/test/utils.py
+++ b/test/utils.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 
 """Utilities for the system test"""
+
 import json
 import shlex
 import subprocess


### PR DESCRIPTION
- **Update deprecated ruff linter settings**
- **Update pre-commit-ruff**
- **ruff formatting and autofixes**
- **Ignore ruff ASYNC101 for async file opening**
- **Fix for ruff `LOG002`**

Related to #305 