### PR TITLE
Allow python 3.12 for cli

### DIFF
--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -10,8 +10,6 @@ dependencies = [
     "core",
     "click==8.1.3",
     "coloredlogs==15.0.1",
-    "pandas==1.5.1",
-    "pyarrow==14.0.1",
 ]
 
 [project.optional-dependencies]

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.0.4"
 authors = [{ name = "PIXL authors" }]
 description = "PIXL command line interface"
 readme = "README.md"
-requires-python = "<3.12"
+requires-python = ">=3.10"
 classifiers = ["Programming Language :: Python :: 3"]
 dependencies = [
     "core",

--- a/pixl_core/pyproject.toml
+++ b/pixl_core/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "jsonpickle==3.0.2",
     "sqlalchemy==2.0.24",
     "psycopg2-binary==2.9.9",
-    "pandas==1.5.1",
+    "pandas==2.2.1",
     "pyarrow==14.0.1",
     "PyYAML==6.0.1",
     "pydantic==2.6.3",


### PR DESCRIPTION
Don't want to have to recreate another set of envs on the GAE next time we upgrade. So allowing greater than 3.10