### PR TITLE
Get mypy working a bit better

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,7 @@ repos:
       rev: v1.9.0
       hooks:
           - id: mypy
+            entry: mypy .
             args: [--config-file=mypy.ini]
             pass_filenames: false
             additional_dependencies:


### PR DESCRIPTION
Possibly fixes #305 

I wish I understood why this worked, but at least mypy is giving reasonable looking errors with it now.

I'll leave this PR as a starting point for the next person who picks this up - I assume we want to fix all the errors as part of the fix? (Remember to merge/rebase first though)

According to https://github.com/pre-commit/mirrors-mypy/blob/main/.pre-commit-hooks.yaml the default value is `entry: mypy`. However, running the command line `mypy` manually does show some errors, so this is not the whole story!

`pre-commit` does run commands inside its own environment so it's possible that has an effect.

So, to summarise:
| command | result |
| --- | --- |
| `mypy` | Found 13 errors in 6 files (checked 71 source files) |
| `mypy .` | Found 67 errors in 23 files (checked 66 source files) |
| (without "entry" fix) `pre-commit run --all-files --verbose ` | Success: no issues found in 71 source files |
| (with "entry" fix) - `pre-commit run --all-files --verbose ` | Found 59 errors in 18 files (checked 66 source files) |

Make that make sense!

(`mypy.ini` is being read in all cases - put in a bad config option and it'll warn you)
