### PR TITLE
Allow merging multiple tag schemas

### DIFF
--- a/pixl_dcmd/src/pixl_dcmd/main.py
+++ b/pixl_dcmd/src/pixl_dcmd/main.py
@@ -96,25 +96,31 @@ def anonymise_dicom(dataset: Dataset) -> Dataset:
     return dataset
 
 
-# TODO: implement this, so that we can merge multiple tag schemes, including those for specific
-# manufacturers
-# NOTE that the tag schemes are LISTs of dictionaries! So will need to come up with a clever way
-# to merge them.
 def merge_tag_schemes(tag_operation_files: list[Path]) -> list[dict]:
+    """Merge multiple tag schemes into a single scheme."""
+    all_tags: dict[tuple, dict] = {}
+
+    for tag_operation_file in tag_operation_files:
+        with tag_operation_file.open() as file:
+            # Load tag operations scheme from YAML.
+            tags = yaml.safe_load(file)
+            if not isinstance(tags, list) or not all(
+                [isinstance(tag, dict) for tag in tags]
+            ):
+                raise ValueError(
+                    "Tag operation file must contain a list of dictionaries"
+                )
+            all_tags.update(_scheme_list_to_dict(tags))
+
+    return list(all_tags.values())
+
+
+def _scheme_list_to_dict(tags: list[dict]) -> dict[tuple, dict]:
     """
-    NOT IMPLEMENTED, WORKS ONLY WITH A SINGLE TAG SCHEME
-    Merge multiple tag schemes into a single dictionary.
+    Convert a list of tag dictionaries to a dictionary of dictionaries.
+    Each group/element pair uniquely identifies a tag.
     """
-    if len(tag_operation_files) > 1:
-        raise NotImplementedError("Multiple tag schemes not supported")
-    with tag_operation_files[0].open() as file:
-        # Load tag operations scheme from YAML.
-        tags = yaml.safe_load(file)
-        if not isinstance(tags, list) or not all(
-            [isinstance(tag, dict) for tag in tags]
-        ):
-            raise ValueError("Tag operation file must contain a list of dictionaries")
-        return tags
+    return {(tag["group"], tag["element"]): tag for tag in tags}
 
 
 def remove_overlays(dataset: Dataset) -> Dataset:

--- a/pixl_dcmd/src/pixl_dcmd/main.py
+++ b/pixl_dcmd/src/pixl_dcmd/main.py
@@ -96,6 +96,10 @@ def anonymise_dicom(dataset: Dataset) -> Dataset:
     return dataset
 
 
+# TODO: implement this, so that we can merge multiple tag schemes, including those for specific
+# manufacturers
+# NOTE that the tag schemes are LISTs of dictionaries! So will need to come up with a clever way
+# to merge them.
 def merge_tag_schemes(tag_operation_files: list[Path]) -> list[dict]:
     """
     NOT IMPLEMENTED, WORKS ONLY WITH A SINGLE TAG SCHEME

--- a/pixl_dcmd/tests/test_main.py
+++ b/pixl_dcmd/tests/test_main.py
@@ -143,3 +143,14 @@ def test_merge_tag_schemes_single_file():
         / "projects/configs/tag-operations/test-extract-uclh-omop-cdm.yaml"
     )
     merge_tag_schemes([tag_ops_file])
+
+
+def test_merge_multiple_tag_schemes():
+    base_tag_ops_file = (
+        pathlib.Path(__file__).parents[2]
+        / "projects/configs/tag-operations/test-extract-uclh-omop-cdm.yaml"
+    )
+    # Merging the same file twice should be the same as merging it once
+    expected = merge_tag_schemes([base_tag_ops_file])
+    result = merge_tag_schemes([base_tag_ops_file, base_tag_ops_file])
+    assert result == expected


### PR DESCRIPTION
In preparation of #292. So we can merge the manufacturer overrides with the base tag schema.

- **Add simple test for merging multiple tag schemes**
- **Implement merging multiple tag schemes**
