### PR TITLE
Various fixes to config code and tests

### DIFF
--- a/pixl_core/pyproject.toml
+++ b/pixl_core/pyproject.toml
@@ -47,7 +47,3 @@ extend = "../ruff.toml"
 
 [tool.ruff.lint.extend-per-file-ignores]
 "./tests/**" = ["D100"]
-
-[tool.ruff.lint.pep8-naming]
-# Allow Pydantic's `@field_validator` decorator to trigger class method treatment.
-classmethod-decorators = ["classmethod", "pydantic.field_validator"]

--- a/pixl_core/src/core/project_config.py
+++ b/pixl_core/src/core/project_config.py
@@ -56,7 +56,7 @@ def _load_and_validate(filename: Path) -> PixlConfig | Any:
 
 class _Project(BaseModel):
     name: str
-    azure_kv_alias: Optional[str]
+    azure_kv_alias: Optional[str] = None
     modalities: list[str]
 
 
@@ -87,6 +87,7 @@ class PixlConfig(BaseModel):
     destination: _Destination
 
     @field_validator("tag_operation_files")
+    @classmethod
     def _valid_tag_operations(cls, tag_ops_files: list[str]) -> list[Path]:
         if not tag_ops_files or len(tag_ops_files) == 0:
             msg = "There should be at least 1 tag operations file"
@@ -96,7 +97,12 @@ class PixlConfig(BaseModel):
             msg = "There should currently be at most 1 tag operations file."
             raise ValueError(msg)
 
-        # Pydantic will automatically check if the file exists
-        return [
+        # Pydantic does not appear to automatically check if the file exists
+        files = [
             PROJECT_CONFIGS_DIR / "tag-operations" / tag_ops_file for tag_ops_file in tag_ops_files
         ]
+        for f in files:
+            if not f.exists():
+                # For pydantic, you must raise a ValueError (or AssertionError)
+                raise ValueError from FileNotFoundError(f)
+        return files

--- a/pixl_core/src/core/project_config.py
+++ b/pixl_core/src/core/project_config.py
@@ -72,6 +72,7 @@ class _Destination(BaseModel):
     parquet: _DestinationEnum
 
     @field_validator("parquet")
+    @classmethod
     def valid_parquet_destination(cls, v: str) -> str:
         if v == "dicomweb":
             msg = "Parquet destination cannot be dicomweb"

--- a/pixl_core/tests/test_project_config.py
+++ b/pixl_core/tests/test_project_config.py
@@ -37,36 +37,59 @@ def test_config_from_file():
     assert project_config.destination.parquet == "ftps"
 
 
-BASE_YAML_DATA = {
-    "project": {"name": "myproject", "modalities": ["DX", "CR"]},
-    "tag_operations": ["test-extract-uclh-omop-cdm.yaml"],
-    "destination": {"dicom": "ftps", "parquet": "ftps"},
-}
+@pytest.fixture()
+def base_yaml_data():
+    """Good data (excluding optional fields)"""
+    return {
+        "project": {"name": "myproject", "modalities": ["DX", "CR"]},
+        "tag_operation_files": ["test-extract-uclh-omop-cdm.yaml"],
+        "destination": {"dicom": "ftps", "parquet": "ftps"},
+    }
 
 
-def test_parquet_dicom_fails():
+def test_base_is_valid(base_yaml_data):
+    """Before anything else, check that the unaltered baseline validates ok."""
+    PixlConfig.model_validate(base_yaml_data)
+
+
+def test_parquet_dicom_fails(base_yaml_data):
     """
     Test that the config validation fails for non-valid values: 'dicomweb' not allowed for
     parquet destionation
     """
-    config_data = BASE_YAML_DATA
+    config_data = base_yaml_data
     config_data["destination"]["parquet"] = "dicomweb"
     with pytest.raises(ValidationError):
         PixlConfig.model_validate(config_data)
 
 
-def test_invalid_destinations():
+def test_invalid_destinations(base_yaml_data):
     """Test that the config validation fails for invalid destinations."""
-    config_data = BASE_YAML_DATA
+    config_data = base_yaml_data
     config_data["destination"]["dicom"] = "nope"
     config_data["destination"]["parquet"] = "nope"
     with pytest.raises(ValidationError):
         PixlConfig.model_validate(config_data)
 
 
-def test_invalid_paths():
+def test_too_many_paths(base_yaml_data):
+    """Test that the config validation fails if there are >1 tag operation files"""
+    config_data_extra_file = base_yaml_data
+    tof = config_data_extra_file["tag_operation_files"]
+    tof.append(tof[0])
+    with pytest.raises(ValidationError, match="at most 1"):
+        PixlConfig.model_validate(config_data_extra_file)
+
+
+def test_invalid_paths(base_yaml_data):
     """Test that the config validation fails for invalid tag-operation paths."""
-    config_data_wrong_base = BASE_YAML_DATA
-    config_data_wrong_base["tag_operations"][0] = "/i/dont/exist.yaml"
+    config_data_wrong_base = base_yaml_data
+    config_data_wrong_base["tag_operation_files"][0] = "/i/dont/exist.yaml"
     with pytest.raises(ValidationError):
         PixlConfig.model_validate(config_data_wrong_base)
+
+
+@pytest.mark.parametrize(("yaml_file"), PROJECT_CONFIGS_DIR.glob("*.yaml"))
+def test_all_real_configs(yaml_file):
+    """Test that all production configs are valid"""
+    _load_and_validate(yaml_file)


### PR DESCRIPTION
- Optional fields are now truly optional
- Check tag op files exist
- Each test was repeatedly modifying the same test data; use a fixture instead
- Base data had some out of date field names; now validate the baseline data before trying to break anything
- Check that all production configs are valid