### PR TITLE
Increase timeout for `imaging-api` test containers

### DIFF
--- a/pixl_imaging/tests/conftest.py
+++ b/pixl_imaging/tests/conftest.py
@@ -67,7 +67,7 @@ def run_containers() -> subprocess.CompletedProcess[bytes]:
     yield run_subprocess(
         shlex.split("docker compose up --build --wait"),
         TEST_DIR,
-        timeout=120,
+        timeout=180,
     )
     run_subprocess(
         shlex.split("docker compose down --volumes"),


### PR DESCRIPTION
The `imaging-api` test frequently fails on CI, because building (or waiting) for the docker containers takes longer than the specified `timeout`. Increasing `timeout` to 3 minutes to prevent this.