### PR TITLE
Include `project_slug` in Image PIXL database queries

### DIFF
--- a/pixl_core/pyproject.toml
+++ b/pixl_core/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "fastapi==0.109.1",
     "token-bucket==0.3.0",
     "python-decouple==3.6",
-    "python-slugify==8.0.1",
+    "python-slugify==8.0.4",
     "pika==1.3.1",
     "aio_pika==8.2.4",
     "requests==2.31.0",

--- a/pixl_dcmd/src/pixl_dcmd/_database.py
+++ b/pixl_dcmd/src/pixl_dcmd/_database.py
@@ -14,9 +14,9 @@
 
 """Interaction with the PIXL database."""
 
-from decouple import config
+from decouple import config  # type: ignore [import-untyped]
 
-from core.db.models import Image
+from core.db.models import Image, Extract  # type: ignore [import-untyped]
 from sqlalchemy import URL, create_engine
 from sqlalchemy.orm import sessionmaker
 
@@ -53,12 +53,14 @@ def add_hashed_identifier_and_save_to_db(
         return updated_image
 
 
-def query_db(mrn: str, accession_number: str) -> Image:
+def query_db(project_slug: str, mrn: str, accession_number: str) -> Image:
     PixlSession = sessionmaker(engine)
     with PixlSession() as pixl_session, pixl_session.begin():
         existing_image: Image = (
             pixl_session.query(Image)
+            .join(Extract)
             .filter(
+                Extract.slug == project_slug,
                 Image.accession_number == accession_number,
                 Image.mrn == mrn,
                 Image.exported_at == None,  # noqa: E711

--- a/pixl_dcmd/src/pixl_dcmd/_database.py
+++ b/pixl_dcmd/src/pixl_dcmd/_database.py
@@ -16,7 +16,7 @@
 
 from decouple import config  # type: ignore [import-untyped]
 
-from core.db.models import Image, Extract  # type: ignore [import-untyped]
+from core.db.models import Image, Extract
 from sqlalchemy import URL, create_engine
 from sqlalchemy.orm import sessionmaker
 

--- a/pixl_dcmd/src/pixl_dcmd/main.py
+++ b/pixl_dcmd/src/pixl_dcmd/main.py
@@ -168,7 +168,7 @@ def _secure_hash(
 
             hashed_value = _hash_values(pat_value, project_slug)
             # Query PIXL database
-            existing_image = query_db(mrn, accession_number)
+            existing_image = query_db(project_slug, mrn, accession_number)
             # Insert the hashed_value into the PIXL database
             add_hashed_identifier_and_save_to_db(existing_image, hashed_value)
         elif dataset[grp, el].VR == "SH":

--- a/pixl_dcmd/tests/conftest.py
+++ b/pixl_dcmd/tests/conftest.py
@@ -71,7 +71,7 @@ def rows_in_session(db_session) -> Session:
 @pytest.fixture()
 def row_for_dicom_testing(db_session) -> Session:
     """Insert a test row for each table, returning the session for use in tests."""
-    extract = Extract(slug="dicom-testing-project")
+    extract = Extract(slug=TEST_PROJECT_SLUG)
 
     image_not_exported = Image(
         accession_number="BB01234567",

--- a/pixl_dcmd/tests/conftest.py
+++ b/pixl_dcmd/tests/conftest.py
@@ -15,6 +15,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Generator
 import datetime
 import os
 import pathlib
@@ -87,7 +88,7 @@ def row_for_dicom_testing(db_session) -> Session:
 
 
 @pytest.fixture()
-def directory_of_mri_dicoms() -> pathlib.Path:
+def directory_of_mri_dicoms() -> Generator[pathlib.Path, None, None]:
     """Directory containing MRI DICOMs suitable for testing."""
     with tempfile.TemporaryDirectory() as td:
         pytest_pixl.dicom.write_volume(td + "/{slice}.dcm")
@@ -106,7 +107,7 @@ def monkeymodule():
 
 
 @pytest.fixture(autouse=True, scope="module")
-def db_engine(monkeymodule) -> Engine:
+def db_engine(monkeymodule) -> Generator[Engine, None, None]:
     """
     Patches the database engine with an in memory database
 
@@ -129,7 +130,7 @@ def db_engine(monkeymodule) -> Engine:
 
 
 @pytest.fixture()
-def db_session(db_engine) -> Session:
+def db_session(db_engine) -> Generator[Session, None, None]:
     """
     Creates a session for interacting with an in memory database.
 


### PR DESCRIPTION
This should allow running multiple projects with the same or overlapping studies without having to
tear down and rebuild the entire setup.

Necessary for #379.

