### PR TITLE
Add healthchecks to orthanc servers in imaging test

### DIFF
--- a/pixl_imaging/tests/docker-compose.yml
+++ b/pixl_imaging/tests/docker-compose.yml
@@ -17,6 +17,18 @@ volumes:
     orthanc-raw-data:
     vna-qr-data:
 
+x-orthanc-healthcheck: &orthanc-healthcheck
+    healthcheck:
+        test:
+          [
+              "CMD-SHELL",
+              "/probes/test-aliveness.py --user=$ORTHANC_USERNAME --pwd=$ORTHANC_PASSWORD",
+          ]
+        start_period: 10s
+        retries: 10
+        interval: 3s
+        timeout: 2s
+
 services:
     vna-qr:
         image: orthancteam/orthanc:24.3.3
@@ -33,6 +45,7 @@ services:
             - "8043:8042"
         volumes:
             - ../../test/vna_config/:/run/secrets:ro
+        <<: *orthanc-healthcheck
 
     orthanc-raw:
         build:
@@ -57,3 +70,4 @@ services:
         volumes:
             # Overriding config for the test
             - ./orthanc_raw_config/:/run/secrets:ro
+        <<: *orthanc-healthcheck


### PR DESCRIPTION
I noticed the imaging test was failing intermittently. The error occurs when trying to upload test data with curl. It wasn't waiting for orthanc to be up before running this command.

Running pytest on command line:
Without fix:
Failed 8 times out of 100

With fix:
Failed 0 times out of 100