### PR TITLE
Don't expose ports on all interfaces unless needed

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -244,7 +244,7 @@ services:
             retries: 3
         ports:
             - "127.0.0.1:${RABBITMQ_PORT}:5672"
-            - "127.0.0.1:${RABBITMQ_ADMIN_PORT}:15672"
+            - "${RABBITMQ_ADMIN_PORT}:15672"
         networks:
             - pixl-net
         volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,7 +94,7 @@ services:
         env_file:
             - ./docker/common.env
         ports:
-            - "${HASHER_API_PORT}:8000"
+            - "127.0.0.1:${HASHER_API_PORT}:8000"
         volumes:
             - *logs-volume
         networks:
@@ -243,8 +243,8 @@ services:
             timeout: 30s
             retries: 3
         ports:
-            - "${RABBITMQ_PORT}:5672"
-            - "${RABBITMQ_ADMIN_PORT}:15672"
+            - "127.0.0.1:${RABBITMQ_PORT}:5672"
+            - "127.0.0.1:${RABBITMQ_ADMIN_PORT}:15672"
         networks:
             - pixl-net
         volumes:
@@ -281,7 +281,7 @@ services:
             hasher-api:
                 condition: service_healthy
         ports:
-            - "${PIXL_EXPORT_API_PORT}:8000"
+            - "127.0.0.1:${PIXL_EXPORT_API_PORT}:8000"
         healthcheck:
             interval: 10s
             timeout: 30s
@@ -331,7 +331,7 @@ services:
             PIXL_QUERY_TIMEOUT: ${PIXL_QUERY_TIMEOUT}
             PIXL_MAX_MESSAGES_IN_FLIGHT: ${PIXL_MAX_MESSAGES_IN_FLIGHT}
         ports:
-            - "${PIXL_IMAGING_API_PORT}:8000"
+            - "127.0.0.1:${PIXL_IMAGING_API_PORT}:8000"
 
     ################################################################################
     # Data Stores
@@ -354,7 +354,7 @@ services:
               source: postgres-data
               target: /var/lib/postgresql/data
         ports:
-            - "${POSTGRES_PORT}:5432"
+            - "127.0.0.1:${POSTGRES_PORT}:5432"
         healthcheck:
             test: ["CMD", "pg_isready", "-U", "${PIXL_DB_USER}"]
             interval: 10s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -354,7 +354,7 @@ services:
               source: postgres-data
               target: /var/lib/postgresql/data
         ports:
-            - "127.0.0.1:${POSTGRES_PORT}:5432"
+            - "${POSTGRES_PORT}:5432"
         healthcheck:
             test: ["CMD", "pg_isready", "-U", "${PIXL_DB_USER}"]
             interval: 10s

--- a/pixl_core/tests/docker-compose.yml
+++ b/pixl_core/tests/docker-compose.yml
@@ -22,8 +22,8 @@ services:
             RABBITMQ_DEFAULT_USER: guest
             RABBITMQ_DEFAULT_PASS: guest
         ports:
-            - "25672:5672"
-            - "35672:15672"
+            - "127.0.0.1:25672:5672"
+            - "127.0.0.1:35672:15672"
         healthcheck:
             test: rabbitmq-diagnostics -q check_running
             interval: 10s
@@ -43,8 +43,8 @@ services:
             RAW_IP_ADDR: "orthanc-raw" # aka. hostname
             DICOM_WEB_PLUGIN_ENABLED: true
         ports:
-            - "4243:4242"
-            - "8043:8042"
+            - "127.0.0.1:4243:4242"
+            - "127.0.0.1:8043:8042"
         networks:
             - pixl-test
         healthcheck:
@@ -67,8 +67,8 @@ services:
             RAW_IP_ADDR: "dicom-web" # aka. hostname
             DICOM_WEB_PLUGIN_ENABLED: true
         ports:
-            - "4244:4242"
-            - "8044:8042"
+            - "127.0.0.1:4244:4242"
+            - "127.0.0.1:8044:8042"
         volumes:
             - ../../test/dicomweb_config/:/run/secrets:ro
         networks:

--- a/pixl_export/tests/docker-compose.yml
+++ b/pixl_export/tests/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       POSTGRES_DB: pixl
       PGTZ: Europe/London
     ports:
-      - "35432:5432"
+      - "127.0.0.1:35432:5432"
     env_file:
       - ../../docker/common.env
     command: postgres -c 'config_file=/etc/postgresql/postgresql.conf'

--- a/pixl_imaging/tests/docker-compose.yml
+++ b/pixl_imaging/tests/docker-compose.yml
@@ -29,8 +29,8 @@ services:
             RAW_DICOM_PORT: "4242"
             RAW_IP_ADDR: "orthanc-raw" # aka. hostname
         ports:
-            - "4243:4242"
-            - "8043:8042"
+            - "127.0.0.1:4243:4242"
+            - "127.0.0.1:8043:8042"
         volumes:
             - ../../test/vna_config/:/run/secrets:ro
 
@@ -52,8 +52,8 @@ services:
             ORTHANC_AUTOROUTE_RAW_TO_ANON: "false"
             PROJECT_CONFIGS_DIR: "/projects/configs"
         ports:
-            - "4244:4242"
-            - "8044:8042"
+            - "127.0.0.1:4244:4242"
+            - "127.0.0.1:8044:8042"
         volumes:
             # Overriding config for the test
             - ./orthanc_raw_config/:/run/secrets:ro

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -30,8 +30,8 @@ services:
             RAW_DICOM_PORT: "4242"
             RAW_IP_ADDR: "orthanc-raw" # aka. hostname
         ports:
-            - "4243:4242"
-            - "8043:8042"
+            - "127.0.0.1:4243:4242"
+            - "127.0.0.1:8043:8042"
         volumes:
             - ./vna_config/:/run/secrets:ro
         healthcheck:
@@ -55,8 +55,8 @@ services:
             RAW_IP_ADDR: "dicomweb-server" # aka. hostname
             DICOM_WEB_PLUGIN_ENABLED: true
         ports:
-            - "4244:4242"
-            - "8044:8042"
+            - "127.0.0.1:4244:4242"
+            - "127.0.0.1:8044:8042"
         volumes:
             - ./dicomweb_config/:/run/secrets:ro
         networks:


### PR DESCRIPTION
Partially addresses #239 (fixing rather than auditing)

Most open ports only need to be accessed from the CLI that's running on the same host. So only listen on localhost.

Similar principal applies to running tests, although those usually won't be run in the hospital.

Orthanc raw and anon are a notable exception as someone may want to view those from the DSD or another hospital computer, but otherwise exposing everything to (perhaps) the whole hospital is a security hazard.