### PR TITLE
Add in extra private tags for philips

### DIFF
--- a/pixl_core/src/core/project_config/pixl_config_model.py
+++ b/pixl_core/src/core/project_config/pixl_config_model.py
@@ -65,7 +65,7 @@ class TagOperationFiles(BaseModel):
     """Tag operations files for a project. At least a base file is required."""
 
     base: list[Path]
-    manufacturer_overrides: Optional[Path]
+    manufacturer_overrides: Optional[list[Path]]
 
     @field_validator("base")
     @classmethod
@@ -87,16 +87,24 @@ class TagOperationFiles(BaseModel):
 
     @field_validator("manufacturer_overrides")
     @classmethod
-    def _valid_manufacturer_overrides(cls, tags_file: str) -> Optional[Path]:
-        if not tags_file:
+    def _valid_manufacturer_overrides(cls, tag_files: list[str]) -> Optional[list[Path]]:
+        if not tag_files:
             return None
 
-        tags_file_path = Path(config("PROJECT_CONFIGS_DIR")) / "tag-operations" / tags_file
-        # Pydantic does not appear to automatically check if the file exists
-        if not tags_file_path.exists():
-            # For pydantic, you must raise a ValueError (or AssertionError)
-            raise ValueError from FileNotFoundError(tags_file_path)
-        return tags_file_path
+        tag_file_paths = []
+        for tag_file in tag_files:
+            tag_file_path = (
+                Path(config("PROJECT_CONFIGS_DIR"))
+                / "tag-operations"
+                / "manufacturer-overrides"
+                / tag_file
+            )
+            # Pydantic does not appear to automatically check if the file exists
+            if not tag_file_path.exists():
+                # For pydantic, you must raise a ValueError (or AssertionError)
+                raise ValueError from FileNotFoundError(tag_file_path)
+            tag_file_paths.append(tag_file_path)
+        return tag_file_paths
 
 
 class _DestinationEnum(str, Enum):

--- a/pixl_core/src/core/project_config/tag_operations.py
+++ b/pixl_core/src/core/project_config/tag_operations.py
@@ -61,7 +61,7 @@ class TagOperations(BaseModel):
     """
 
     base: list[list[dict]]
-    manufacturer_overrides: Optional[list[dict]]
+    manufacturer_overrides: Optional[list[list[dict]]]
 
     @field_validator("base")
     @classmethod
@@ -77,19 +77,20 @@ class TagOperations(BaseModel):
     @field_validator("manufacturer_overrides")
     @classmethod
     def _valid_manufacturer_overrides(
-        cls, manufacturer_overrides: Optional[list[dict]]
-    ) -> Optional[list[dict]]:
+        cls, manufacturer_overrides: Optional[list[list[dict]]]
+    ) -> Optional[list[list[dict]]]:
         if manufacturer_overrides is None:
             return None
-        if not isinstance(manufacturer_overrides, list):
-            msg = "Tags must be a list of dictionaries."
-            raise TypeError(msg)
-        for override in manufacturer_overrides:
-            if "manufacturer" not in override or "tags" not in override:
-                msg = "Manufacturer overrides must have 'manufacturer' and 'tags' keys."
-                raise ValueError(msg)
-            for tag in override["tags"]:
-                _check_tag_format(tag)
+        for manufacturer_override in manufacturer_overrides:
+            if not isinstance(manufacturer_override, list):
+                msg = "Tags must be a list of dictionaries."
+                raise TypeError(msg)
+            for override in manufacturer_override:
+                if "manufacturer" not in override or "tags" not in override:
+                    msg = "Manufacturer overrides must have 'manufacturer' and 'tags' keys."
+                    raise ValueError(msg)
+                for tag in override["tags"]:
+                    _check_tag_format(tag)
 
         return manufacturer_overrides
 

--- a/pixl_core/src/core/project_config/tag_operations.py
+++ b/pixl_core/src/core/project_config/tag_operations.py
@@ -40,12 +40,12 @@ def load_tag_operations(pixl_config: PixlConfig) -> TagOperations:
     :param pixl_config: Project configuration
     """
     base = [_load_scheme(f) for f in pixl_config.tag_operation_files.base]
-    manufacturer_overrides = None
+    manufacturer_overrides = []
 
     if pixl_config.tag_operation_files.manufacturer_overrides:
-        manufacturer_overrides = _load_scheme(
-            pixl_config.tag_operation_files.manufacturer_overrides
-        )
+        for override_file in pixl_config.tag_operation_files.manufacturer_overrides:
+            override_dict = _load_scheme(override_file)
+            manufacturer_overrides.append(override_dict)
 
     return TagOperations(base=base, manufacturer_overrides=manufacturer_overrides)
 

--- a/pixl_core/tests/project_config/test_project_config.py
+++ b/pixl_core/tests/project_config/test_project_config.py
@@ -121,7 +121,7 @@ def test_load_tag_operations_no_manufacturer_overrides(base_yaml_data):
     tag_operations = load_tag_operations(project_config)
 
     # Assert
-    assert tag_operations.manufacturer_overrides is None
+    assert tag_operations.manufacturer_overrides == []
 
 
 @pytest.fixture()

--- a/pixl_core/tests/project_config/test_project_config.py
+++ b/pixl_core/tests/project_config/test_project_config.py
@@ -42,7 +42,7 @@ def base_yaml_data():
         "project": {"name": "myproject", "modalities": ["DX", "CR"]},
         "tag_operation_files": {
             "base": ["test-extract-uclh-omop-cdm.yaml"],
-            "manufacturer_overrides": "manufacturer-overrides/mri-diffusion.yaml",
+            "manufacturer_overrides": ["mri-diffusion.yaml"],
         },
         "destination": {"dicom": "ftps", "parquet": "ftps"},
     }

--- a/pixl_dcmd/src/pixl_dcmd/_tag_schemes.py
+++ b/pixl_dcmd/src/pixl_dcmd/_tag_schemes.py
@@ -33,13 +33,14 @@ def merge_tag_schemes(
         all_tags.update(_scheme_list_to_dict(base_tags))
 
     if tag_operations.manufacturer_overrides and manufacturer:
-        manufacturer_tags = [
-            tag
-            for override in tag_operations.manufacturer_overrides
-            if re.search(override["manufacturer"], manufacturer, re.IGNORECASE)
-            for tag in override["tags"]
-        ]
-        all_tags.update(_scheme_list_to_dict(manufacturer_tags))
+        for override_file in tag_operations.manufacturer_overrides:
+            manufacturer_tags = [
+                tag
+                for override in override_file
+                if re.search(override["manufacturer"], manufacturer, re.IGNORECASE)
+                for tag in override["tags"]
+            ]
+            all_tags.update(_scheme_list_to_dict(manufacturer_tags))
 
     return list(all_tags.values())
 

--- a/pixl_dcmd/tests/test_main.py
+++ b/pixl_dcmd/tests/test_main.py
@@ -64,9 +64,11 @@ def _mri_diffusion_tags(manufacturer: str = "Philips") -> list[PrivateDicomTag]:
     """
     project_config = load_project_config(TEST_PROJECT_SLUG)
     tag_ops = load_tag_operations(project_config)
+    mri_diffusion_overrides = tag_ops.manufacturer_overrides[0]
+
     manufacturer_overrides = [
         override
-        for override in tag_ops.manufacturer_overrides
+        for override in mri_diffusion_overrides
         if re.search(override["manufacturer"], manufacturer, re.IGNORECASE)
     ][0]
 

--- a/pixl_dcmd/tests/test_tag_schemes.py
+++ b/pixl_dcmd/tests/test_tag_schemes.py
@@ -68,24 +68,34 @@ def tag_ops_with_manufacturer_overrides(tmp_path_factory):
         {"name": "tag3", "group": 0x003, "element": 0x1002, "op": "delete"},
     ]
     manufacturer_overrides_tags = [
-        {
-            "manufacturer": "manufacturer_1",
-            "tags": [
-                # Override tag1 for manufacturer 1
-                {"name": "tag1", "group": 0x001, "element": 0x1000, "op": "keep"},
-                {"name": "tag4", "group": 0x004, "element": 0x1011, "op": "delete"},
-                {"name": "tag5", "group": 0x005, "element": 0x1012, "op": "delete"},
-            ],
-        },
-        {
-            "manufacturer": "manufacturer_2",
-            "tags": [
-                {"name": "tag6", "group": 0x006, "element": 0x1100, "op": "keep"},
-                {"name": "tag7", "group": 0x007, "element": 0x1111, "op": "delete"},
-                # Override tag3 for manufacturer 2
-                {"name": "tag3", "group": 0x003, "element": 0x1002, "op": "keep"},
-            ],
-        },
+        [
+            {
+                "manufacturer": "manufacturer_1",
+                "tags": [
+                    # Override tag1 for manufacturer 1
+                    {"name": "tag1", "group": 0x001, "element": 0x1000, "op": "keep"},
+                    {"name": "tag4", "group": 0x004, "element": 0x1011, "op": "delete"},
+                ],
+            },
+            {
+                "manufacturer": "manufacturer_2",
+                "tags": [
+                    {"name": "tag6", "group": 0x006, "element": 0x1100, "op": "keep"},
+                    {"name": "tag7", "group": 0x007, "element": 0x1111, "op": "delete"},
+                    # Override tag3 for manufacturer 2
+                    {"name": "tag3", "group": 0x003, "element": 0x1002, "op": "keep"},
+                ],
+            },
+        ],
+        [
+            {
+                "manufacturer": "manufacturer_1",
+                "tags": [
+                    # Override tag1 for manufacturer 1
+                    {"name": "tag5", "group": 0x005, "element": 0x1012, "op": "delete"},
+                ],
+            },
+        ],
     ]
 
     return TagOperations(

--- a/projects/configs/ms-pinpoint-internal-only.yaml
+++ b/projects/configs/ms-pinpoint-internal-only.yaml
@@ -20,7 +20,7 @@ tag_operation_files:
     base:
         - "mri.yaml"
         - "ms-pinpoint.yaml"
-    manufacturer_overrides: null
+    manufacturer_overrides: ["mri.yaml"]
 
 series_filters:
     - "localizer"

--- a/projects/configs/tag-operations/manufacturer-overrides/mri-diffusion.yaml
+++ b/projects/configs/tag-operations/manufacturer-overrides/mri-diffusion.yaml
@@ -18,14 +18,6 @@
     - group: 0x2001
       element: 0x1003
       op: "keep"
-    - name: "Flip angle" # public version can have rounding issues, may need to have this for all MRs rather than just DW?
-      group: 0x2001
-      element: 0x1023
-      op: "keep"
-    - name: "Scale Slope" # may need to have this for all MRs rather than just DW?
-      group: 0x2005
-      element: 0x100e
-      op: "keep"
     - group: 0x2005
       element: 0x10b0
       op: "keep"
@@ -34,10 +26,6 @@
       op: "keep"
     - group: 0x2005
       element: 0x10b2
-      op: "keep"
-    - name: "Repetition Time" # public version can have rounding issues, may need to have this for all MRs rather than just DW?
-      group: 0x2005
-      element: 0x1030
       op: "keep"
 
 # Example tags obtained from https://github.com/rordenlab/dcm2niix/blob/master/Siemens/README.md#siemens-x-series

--- a/projects/configs/tag-operations/manufacturer-overrides/mri-diffusion.yaml
+++ b/projects/configs/tag-operations/manufacturer-overrides/mri-diffusion.yaml
@@ -18,7 +18,11 @@
     - group: 0x2001
       element: 0x1003
       op: "keep"
-    - name: "ScaleSlope" # may need to have this for all MRs rather than just DW?
+    - name: "Flip angle" # public version can have rounding issues, may need to have this for all MRs rather than just DW?
+      group: 0x2001
+      element: 0x1023
+      op: "keep"
+    - name: "Scale Slope" # may need to have this for all MRs rather than just DW?
       group: 0x2005
       element: 0x100e
       op: "keep"
@@ -30,6 +34,10 @@
       op: "keep"
     - group: 0x2005
       element: 0x10b2
+      op: "keep"
+    - name: "Repetition Time" # public version can have rounding issues, may need to have this for all MRs rather than just DW?
+      group: 0x2005
+      element: 0x1030
       op: "keep"
 
 # Example tags obtained from https://github.com/rordenlab/dcm2niix/blob/master/Siemens/README.md#siemens-x-series

--- a/projects/configs/tag-operations/manufacturer-overrides/mri.yaml
+++ b/projects/configs/tag-operations/manufacturer-overrides/mri.yaml
@@ -1,0 +1,31 @@
+#  Copyright (c) University College London Hospitals NHS Foundation Trust
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+- manufacturer: ^philips
+  tags:
+    - group: 0x2001
+      element: 0x1003
+      op: "keep"
+    - name: "Flip angle" # public version can have rounding issues
+      group: 0x2001
+      element: 0x1023
+      op: "keep"
+    - name: "Scale Slope"
+      group: 0x2005
+      element: 0x100e
+      op: "keep"
+    - name: "Repetition Time" # public version can have rounding issues
+      group: 0x2005
+      element: 0x1030
+      op: "keep"

--- a/projects/configs/test-extract-uclh-omop-cdm-dicomweb.yaml
+++ b/projects/configs/test-extract-uclh-omop-cdm-dicomweb.yaml
@@ -20,7 +20,7 @@ project:
 tag_operation_files:
     base:
         - "test-extract-uclh-omop-cdm.yaml"
-    manufacturer_overrides: "manufacturer-overrides/mri-diffusion.yaml"
+    manufacturer_overrides: ["mri.yaml", "mri-diffusion.yaml"]
 
 series_filters:
     - "localizer"

--- a/projects/configs/test-extract-uclh-omop-cdm.yaml
+++ b/projects/configs/test-extract-uclh-omop-cdm.yaml
@@ -20,7 +20,7 @@ project:
 tag_operation_files:
     base:
         - "test-extract-uclh-omop-cdm.yaml"
-    manufacturer_overrides: ["mri.yaml", "mri-diffusion.yaml"]
+    manufacturer_overrides: ["mri-diffusion.yaml"]
 
 series_filters:
     - "localizer"

--- a/projects/configs/test-extract-uclh-omop-cdm.yaml
+++ b/projects/configs/test-extract-uclh-omop-cdm.yaml
@@ -20,7 +20,7 @@ project:
 tag_operation_files:
     base:
         - "test-extract-uclh-omop-cdm.yaml"
-    manufacturer_overrides: "manufacturer-overrides/mri-diffusion.yaml"
+    manufacturer_overrides: ["mri.yaml", "mri-diffusion.yaml"]
 
 series_filters:
     - "localizer"

--- a/projects/configs/uclh-prostate-mri-validation-dataset.yaml
+++ b/projects/configs/uclh-prostate-mri-validation-dataset.yaml
@@ -20,7 +20,7 @@ tag_operation_files:
     base:
         - "mri.yaml"
         - "diffusion-weighted-mri.yaml"
-    manufacturer_overrides: "manufacturer-overrides/mri-diffusion.yaml"
+    manufacturer_overrides: ["mri.yaml", "mri-diffusion.yaml"]
 destination:
     dicom: "none"
     parquet: "none"


### PR DESCRIPTION
Feedback from Prostate MRI is that some public tags can have rounding issues, so including private tags. Not sure if its worth just creating a separate override for mri's as a whole?

closes https://github.com/UCLH-Foundry/the-rolling-skeleton/issues/245