### PR TITLE
Set development version

### DIFF
--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 classifiers = ["Programming Language :: Python :: 3"]
 dependencies = [
-    "core==0.1.0",
+    "core>=0.1.0",
     "click==8.1.7",
     "tqdm==4.66.4",
 ]

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pixl_cli"
-version = "0.1.0"
+version = "0.2.0-rc"
 authors = [{ name = "PIXL authors" }]
 description = "PIXL command line interface"
 readme = "README.md"

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -1,13 +1,13 @@
 [project]
 name = "pixl_cli"
-version = "0.2.0-rc"
+version = "0.2.0rc0"
 authors = [{ name = "PIXL authors" }]
 description = "PIXL command line interface"
 readme = "README.md"
 requires-python = ">=3.10"
 classifiers = ["Programming Language :: Python :: 3"]
 dependencies = [
-    "core>=0.1.0",
+    "core==0.2.0rc0",
     "click==8.1.7",
     "tqdm==4.66.4",
 ]

--- a/hasher/pyproject.toml
+++ b/hasher/pyproject.toml
@@ -1,13 +1,13 @@
 [project]
 name = "hasher"
-version = "0.2.0-rc"
+version = "0.2.0rc0"
 authors = [{ name = "PIXL authors" }]
 description = "Service to securely hash identifiers"
 readme = "README.md"
 requires-python = ">=3.10"
 classifiers = ["Programming Language :: Python :: 3"]
 dependencies = [
-    "core>=0.1.0",
+    "core==0.2.0rc0",
     "azure-identity==1.16.1",
     "azure-keyvault==4.2.0",
     "fastapi==0.112.0",

--- a/hasher/pyproject.toml
+++ b/hasher/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hasher"
-version = "0.1.0"
+version = "0.2.0-rc"
 authors = [{ name = "PIXL authors" }]
 description = "Service to securely hash identifiers"
 readme = "README.md"

--- a/hasher/pyproject.toml
+++ b/hasher/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 classifiers = ["Programming Language :: Python :: 3"]
 dependencies = [
-    "core==0.1.0",
+    "core>=0.1.0",
     "azure-identity==1.16.1",
     "azure-keyvault==4.2.0",
     "fastapi==0.112.0",

--- a/pixl_core/pyproject.toml
+++ b/pixl_core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "core"
-version = "0.1.0"
+version = "0.2.0-rc"
 authors = [{ name = "PIXL core functionality" }]
 description = ""
 readme = "README.md"

--- a/pixl_core/pyproject.toml
+++ b/pixl_core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "core"
-version = "0.2.0-rc"
+version = "0.2.0rc0"
 authors = [{ name = "PIXL core functionality" }]
 description = ""
 readme = "README.md"
@@ -32,7 +32,7 @@ test = [
     "pytest-cov==5.0.0",
     "pytest-asyncio==0.23.8",
     "httpx==0.27.*",
-    "pytest-pixl>=0.1.0",
+    "pytest-pixl==0.2.0rc0",
 ]
 dev = ["mypy", "pre-commit", "ruff"]
 

--- a/pixl_core/pyproject.toml
+++ b/pixl_core/pyproject.toml
@@ -32,7 +32,7 @@ test = [
     "pytest-cov==5.0.0",
     "pytest-asyncio==0.23.8",
     "httpx==0.27.*",
-    "pytest-pixl==0.1.0",
+    "pytest-pixl>=0.1.0",
 ]
 dev = ["mypy", "pre-commit", "ruff"]
 

--- a/pixl_dcmd/pyproject.toml
+++ b/pixl_dcmd/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 classifiers = ["Programming Language :: Python :: 3"]
 dependencies = [
-    "core==0.1.0",
+    "core>=0.1.0",
     "arrow==1.3.0",
     "pydicom==2.4.4",
     "pydicom-data",
@@ -20,7 +20,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-test = ["dcm2niix==1.0.20220715", "nibabel==5.2.1", "pytest==8.3.2", "pytest-pixl==0.1.0"]
+test = ["dcm2niix==1.0.20220715", "nibabel==5.2.1", "pytest==8.3.2", "pytest-pixl>=0.1.0"]
 dev = ["mypy", "pre-commit", "ruff"]
 
 [build-system]

--- a/pixl_dcmd/pyproject.toml
+++ b/pixl_dcmd/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pixl_dcmd"
-version = "0.1.0"
+version = "0.2.0-rc"
 authors = [{ name = "PIXL authors" }]
 description = "DICOM header anonymisation functions"
 readme = "README.md"

--- a/pixl_dcmd/pyproject.toml
+++ b/pixl_dcmd/pyproject.toml
@@ -1,13 +1,13 @@
 [project]
 name = "pixl_dcmd"
-version = "0.2.0-rc"
+version = "0.2.0rc0"
 authors = [{ name = "PIXL authors" }]
 description = "DICOM header anonymisation functions"
 readme = "README.md"
 requires-python = ">=3.11"
 classifiers = ["Programming Language :: Python :: 3"]
 dependencies = [
-    "core>=0.1.0",
+    "core==0.2.0rc0",
     "arrow==1.3.0",
     "pydicom==2.4.4",
     "pydicom-data",
@@ -20,7 +20,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-test = ["dcm2niix==1.0.20220715", "nibabel==5.2.1", "pytest==8.3.2", "pytest-pixl>=0.1.0"]
+test = ["dcm2niix==1.0.20220715", "nibabel==5.2.1", "pytest==8.3.2", "pytest-pixl==0.2.0rc0"]
 dev = ["mypy", "pre-commit", "ruff"]
 
 [build-system]

--- a/pixl_export/pyproject.toml
+++ b/pixl_export/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pixl_export"
-version = "0.1.0"
+version = "0.2.0-rc"
 authors = [{ name = "PIXL authors" }]
 description = "PIXL electronic health record extractor"
 readme = "README.md"

--- a/pixl_export/pyproject.toml
+++ b/pixl_export/pyproject.toml
@@ -1,13 +1,13 @@
 [project]
 name = "pixl_export"
-version = "0.2.0-rc"
+version = "0.2.0rc0"
 authors = [{ name = "PIXL authors" }]
 description = "PIXL electronic health record extractor"
 readme = "README.md"
 requires-python = ">=3.10"
 classifiers = ["Programming Language :: Python :: 3"]
 dependencies = [
-    "core>=0.1.0",
+    "core==0.2.0rc0",
     "uvicorn==0.30.4",
     "python-decouple==3.8",
     "psycopg2-binary==2.9.9",

--- a/pixl_export/pyproject.toml
+++ b/pixl_export/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 classifiers = ["Programming Language :: Python :: 3"]
 dependencies = [
-    "core==0.1.0",
+    "core>=0.1.0",
     "uvicorn==0.30.4",
     "python-decouple==3.8",
     "psycopg2-binary==2.9.9",

--- a/pixl_imaging/pyproject.toml
+++ b/pixl_imaging/pyproject.toml
@@ -1,13 +1,13 @@
 [project]
 name = "pixl_imaging"
-version = "0.2.0-rc"
+version = "0.2.0rc0"
 authors = [{ name = "PIXL authors" }]
 description = "PIXL image extractor"
 readme = "README.md"
 requires-python = ">=3.10"
 classifiers = ["Programming Language :: Python :: 3"]
 dependencies = [
-    "core>=0.1.0",
+    "core==0.2.0rc0",
     "aiohttp==3.10.1",
     "alembic==1.13.2",
     "pydicom==2.4.4",
@@ -16,7 +16,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-test = ["pytest==8.3.2", "pytest-asyncio==0.23.8", "pytest-pixl>=0.1.0"]
+test = ["pytest==8.3.2", "pytest-asyncio==0.23.8", "pytest-pixl==0.2.0rc0"]
 dev = ["mypy", "pre-commit", "ruff"]
 
 [build-system]

--- a/pixl_imaging/pyproject.toml
+++ b/pixl_imaging/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 classifiers = ["Programming Language :: Python :: 3"]
 dependencies = [
-    "core==0.1.0",
+    "core>=0.1.0",
     "aiohttp==3.10.1",
     "alembic==1.13.2",
     "pydicom==2.4.4",
@@ -16,7 +16,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-test = ["pytest==8.3.2", "pytest-asyncio==0.23.8", "pytest-pixl==0.1.0"]
+test = ["pytest==8.3.2", "pytest-asyncio==0.23.8", "pytest-pixl>=0.1.0"]
 dev = ["mypy", "pre-commit", "ruff"]
 
 [build-system]

--- a/pixl_imaging/pyproject.toml
+++ b/pixl_imaging/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pixl_imaging"
-version = "0.1.0"
+version = "0.2.0-rc"
 authors = [{ name = "PIXL authors" }]
 description = "PIXL image extractor"
 readme = "README.md"

--- a/pytest-pixl/pyproject.toml
+++ b/pytest-pixl/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
 
 [project.optional-dependencies]
 test = [
-    "core==0.1.0",
+    "core>=0.1.0",
     "pytest==8.3.2",
 ]
 dev = [

--- a/pytest-pixl/pyproject.toml
+++ b/pytest-pixl/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pytest-pixl"
-version = "0.1.0"
+version = "0.2.0-rc"
 authors = [{ name = "PIXL authors" }]
 description = "Pytest plugin for PIXL"
 readme = "README.md"

--- a/pytest-pixl/pyproject.toml
+++ b/pytest-pixl/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pytest-pixl"
-version = "0.2.0-rc"
+version = "0.2.0rc0"
 authors = [{ name = "PIXL authors" }]
 description = "Pytest plugin for PIXL"
 readme = "README.md"
@@ -19,7 +19,7 @@ dependencies = [
 
 [project.optional-dependencies]
 test = [
-    "core>=0.1.0",
+    "core==0.2.0rc0",
     "pytest==8.3.2",
 ]
 dev = [


### PR DESCRIPTION
* Bump module versions to `0.2.0-rc` following the [v0.1.0 release](https://github.com/UCLH-Foundry/PIXL/releases/tag/v0.1.0)
* Update dependency pins for `pixl_core` and `pytest_pixl` to `>=0.1.0`

Closes #473 