### PR TITLE
Make loguru's `'extra'` fields top-level attributes in OTel logs 

### DIFF
--- a/docs/setup/developer.md
+++ b/docs/setup/developer.md
@@ -161,7 +161,7 @@ top-level, queryable attribute on the OTel log record.
 
 When adding context:
 
-- Bind each field as soon as it is known**, e.g. bind `pseudo_study_uid` as soon as
+- Bind each field as soon as it is known, e.g. bind `pseudo_study_uid` as soon as
   a study has been anonymised.
 - Bind fields at the start of a unit of work** using `logger.contextualize(...)`.
   For example, bind `study_uid` per study when iterating over studies, or

--- a/docs/setup/developer.md
+++ b/docs/setup/developer.md
@@ -163,7 +163,7 @@ When adding context:
 
 - Bind each field as soon as it is known, e.g. bind `pseudo_study_uid` as soon as
   a study has been anonymised.
-- Bind fields at the start of a unit of work** using `logger.contextualize(...)`.
+- Bind fields at the start of a unit of work using `logger.contextualize(...)`.
   For example, bind `study_uid` per study when iterating over studies, or
   `orthanc_resource_id` when iterating over resources.
 - For a single log call, `logger.bind(...).info(...)` is preferable to the context manager.

--- a/docs/setup/developer.md
+++ b/docs/setup/developer.md
@@ -151,3 +151,22 @@ collector's UI.
 Leave `OTEL_EXPORTER_OTLP_ENDPOINT` empty (or unset) to disable all telemetry. No
 other configuration is needed — the services detect the absence of the endpoint
 and skip OTel initialisation.
+
+### Adding context to logs
+
+To make logs filterable and to link related logs together (e.g. logs related
+given DICOM study), we attach structured *context fields* to them. Any field bound
+with loguru's `logger.contextualize()` or `logger.bind()` is exported as a
+top-level, queryable attribute on the OTel log record.
+
+When adding context:
+
+- Bind each field as soon as it is known**, e.g. bind `pseudo_study_uid` as soon as
+  a study has been anonymised.
+- Bind fields at the start of a unit of work** using `logger.contextualize(...)`.
+  For example, bind `study_uid` per study when iterating over studies, or
+  `orthanc_resource_id` when iterating over resources.
+- For a single log call, `logger.bind(...).info(...)` is preferable to the context manager.
+- Use the same field names across services so logs can be joined up
+- If a field has been pseudonymised, bind a new field prefixed with `pseudo_`, e.g.
+  `study_uid` becomes `pseudo_study_uid` after pseudonymisation

--- a/orthanc/orthanc-anon/plugin/pixl.py
+++ b/orthanc/orthanc-anon/plugin/pixl.py
@@ -318,8 +318,10 @@ def _anonymise_study_and_upload(
                 logger.exception("Failed to anonymize project: '{}', {}", project_name, study_info)
                 return None
 
-        _upload_instances(anonymised_instances_bytes)
-        logger.bind(pseudo_study_uid=anonymised_study_uid).info("Anonymised and uploaded study")
+        with logger.contextualize(pseudo_study_uid=anonymised_study_uid):
+            _upload_instances(anonymised_instances_bytes)
+            logger.info("Anonymised and uploaded study")
+
         return anonymised_study_uid
 
 
@@ -409,19 +411,20 @@ def _anonymise_study_instances(
         message = f"All instances have been skipped for study: {dict(skipped_instance_counts)}"
         raise PixlDiscardError(message)
 
-    logger.debug(
-        "Project '{}' {}, skipped instances: {}",
-        project_name,
-        study_info,
-        dict(skipped_instance_counts),
-    )
-
-    if dicom_validation_errors:
-        logger.warning(
-            "The anonymisation introduced the following validation errors:\n{}",
-            parse_validation_results(dicom_validation_errors),
+    with logger.contextualize(pseudo_study_uid=anonymised_study_uid):
+        logger.debug(
+            "Project '{}' {}, skipped instances: {}",
+            project_name,
+            study_info,
+            dict(skipped_instance_counts),
         )
-    logger.success("Finished anonymising project: '{}', {}", project_name, study_info)
+
+        if dicom_validation_errors:
+            logger.warning(
+                "The anonymisation introduced the following validation errors:\n{}",
+                parse_validation_results(dicom_validation_errors),
+            )
+        logger.success("Finished anonymising project: '{}', {}", project_name, study_info)
     return anonymised_instances_bytes, anonymised_study_uid
 
 

--- a/orthanc/orthanc-anon/plugin/pixl.py
+++ b/orthanc/orthanc-anon/plugin/pixl.py
@@ -251,7 +251,7 @@ def _import_studies_from_raw(
         anonymised_study_uids = []
 
         for study_resource_id, study_uid in zip(study_resource_ids, study_uids, strict=False):
-            with logger.contextualize(study_uid=study_uid, orthanc_study_id=study_resource_id):
+            with logger.contextualize(study_uid=study_uid, orthanc_resource_id=study_resource_id):
                 logger.debug("Processing project '{}', study '{}' ", project_name, study_uid)
                 anonymised_uid = _anonymise_study_and_upload(
                     study_resource_id, project_name, series_to_keep
@@ -281,7 +281,7 @@ def _import_studies_from_raw(
         for resource_id, anonymised_study_uid in anonymised_study_uid_by_resource_ids.items():
             with logger.contextualize(
                 pseudo_study_uid=anonymised_study_uid,
-                orthanc_study_id=resource_id,
+                orthanc_resource_id=resource_id,
             ):
                 send_study(study_id=resource_id, project_name=project_name)
 

--- a/orthanc/orthanc-anon/plugin/pixl.py
+++ b/orthanc/orthanc-anon/plugin/pixl.py
@@ -247,34 +247,43 @@ def _import_studies_from_raw(
     - Notify the PIXL export-api to send the studies to the relevant endpoint for the project
 
     """
-    anonymised_study_uids = []
+    with logger.contextualize(project_name=project_name):
+        anonymised_study_uids = []
 
-    for study_resource_id, study_uid in zip(study_resource_ids, study_uids, strict=False):
-        logger.debug("Processing project '{}', study '{}' ", project_name, study_uid)
-        anonymised_uid = _anonymise_study_and_upload(
-            study_resource_id, project_name, series_to_keep
+        for study_resource_id, study_uid in zip(study_resource_ids, study_uids, strict=False):
+            with logger.contextualize(study_uid=study_uid, orthanc_study_id=study_resource_id):
+                logger.debug("Processing project '{}', study '{}' ", project_name, study_uid)
+                anonymised_uid = _anonymise_study_and_upload(
+                    study_resource_id, project_name, series_to_keep
+                )
+                if anonymised_uid:
+                    anonymised_study_uids.append(anonymised_uid)
+
+        if not should_export():
+            logger.info(
+                "Not exporting anonymised studies {} as auto-routing is disabled",
+                anonymised_study_uids,
+            )
+            return
+
+        # ensure we only have unique resource ids by using a set
+        anonymised_study_uid_by_resource_ids = {
+            _get_study_resource_id(anonymised_study_uid): anonymised_study_uid
+            for anonymised_study_uid in anonymised_study_uids
+        }
+
+        logger.debug(
+            "Notify export API to retrieve study resources. Original UID {} Anon UID: {}",
+            study_resource_ids,
+            list(anonymised_study_uid_by_resource_ids.values()),
         )
-        if anonymised_uid:
-            anonymised_study_uids.append(anonymised_uid)
 
-    if not should_export():
-        logger.debug("Not exporting study {} as auto-routing is disabled", anonymised_study_uids)
-        return
-
-    # ensure we only have unique resource ids by using a set
-    resource_ids = {
-        _get_study_resource_id(anonymised_study_uid)
-        for anonymised_study_uid in anonymised_study_uids
-    }
-
-    logger.debug(
-        "Notify export API to retrieve study resources. Original UID {} Anon UID: {}",
-        study_resource_ids,
-        resource_ids,
-    )
-
-    for resource_id in resource_ids:
-        send_study(study_id=resource_id, project_name=project_name)
+        for resource_id, anonymised_study_uid in anonymised_study_uid_by_resource_ids.items():
+            with logger.contextualize(
+                pseudo_study_uid=anonymised_study_uid,
+                orthanc_study_id=resource_id,
+            ):
+                send_study(study_id=resource_id, project_name=project_name)
 
 
 def _anonymise_study_and_upload(
@@ -285,27 +294,33 @@ def _anonymise_study_and_upload(
     zipped_study_bytes = get_study_zip_archive_from_raw(resource_id=study_resource_id)
 
     study_info = _get_study_info_from_first_file(zipped_study_bytes)
-    logger.info("Processing project '{}', {}", project_name, study_info)
+    with logger.contextualize(
+        mrn=study_info.mrn,
+        accession_number=study_info.accession_number,
+        study_uid=study_info.study_uid,
+    ):
+        logger.info("Processing project '{}', {}", project_name, study_info)
 
-    with ZipFile(zipped_study_bytes) as zipped_study:
-        try:
-            anonymised_instances_bytes, anonymised_study_uid = _anonymise_study_instances(
-                zipped_study=zipped_study,
-                study_info=study_info,
-                project_name=project_name,
-                series_to_keep=series_to_keep,
-            )
-        except PixlDiscardError as discard:
-            logger.warning(
-                "Failed to anonymize project: '{}', {}: {}", project_name, study_info, discard
-            )
-            return None
-        except Exception:  # noqa: BLE001
-            logger.exception("Failed to anonymize project: '{}', {}", project_name, study_info)
-            return None
+        with ZipFile(zipped_study_bytes) as zipped_study:
+            try:
+                anonymised_instances_bytes, anonymised_study_uid = _anonymise_study_instances(
+                    zipped_study=zipped_study,
+                    study_info=study_info,
+                    project_name=project_name,
+                    series_to_keep=series_to_keep,
+                )
+            except PixlDiscardError as discard:
+                logger.warning(
+                    "Failed to anonymize project: '{}', {}: {}", project_name, study_info, discard
+                )
+                return None
+            except Exception:  # noqa: BLE001
+                logger.exception("Failed to anonymize project: '{}', {}", project_name, study_info)
+                return None
 
-    _upload_instances(anonymised_instances_bytes)
-    return anonymised_study_uid
+        _upload_instances(anonymised_instances_bytes)
+        logger.bind(pseudo_study_uid=anonymised_study_uid).info("Anonymised and uploaded study")
+        return anonymised_study_uid
 
 
 def get_study_zip_archive_from_raw(resource_id: str) -> BytesIO:
@@ -467,8 +482,7 @@ def send_study(study_id: str, project_name: str) -> None:
     Send the resource to the appropriate destination.
     Throws an exception if the image has already been exported.
     """
-    msg = f"Sending {study_id}"
-    logger.debug(msg)
+    logger.debug("Sending {}", study_id)
     notify_export_api_of_readiness(study_id, project_name)
 
 

--- a/pixl_core/src/core/logging.py
+++ b/pixl_core/src/core/logging.py
@@ -79,12 +79,20 @@ class OTelSink:
         # loguru stores time in seconds; OTel expected it in nanoseconds
         timestamp_ns = int(record["time"].timestamp() * 1e9)
 
+        # Make bound fields top-level attributes so they can be directly queried when filtering
+        # logs.
+        attributes: dict[str, object] = dict(record["extra"])
+        attributes["code.filepath"] = record["file"].path
+        attributes["code.lineno"] = record["line"]
+        attributes["code.function"] = record["function"]
+
         exception = record["exception"]
         self.provider.get_logger(record["name"]).emit(
             timestamp=timestamp_ns,
             severity_number=severity_number,
             severity_text=severity_text,
             body=record["message"],
+            attributes=attributes,
             exception=exception.value if exception else None,
         )
 

--- a/pixl_core/src/core/patient_queue/producer.py
+++ b/pixl_core/src/core/patient_queue/producer.py
@@ -49,8 +49,16 @@ class PixlProducer(PixlBlockingInterface):
                         priority=priority,
                     ),
                 )
-                logger.debug(
-                    "Message {} published to queue {} with priority", msg, self.queue_name, priority
+                logger.bind(
+                    project_name=msg.project_name,
+                    mrn=msg.mrn,
+                    accession_number=msg.accession_number,
+                    study_uid=msg.study_uid,
+                ).debug(
+                    "Message {} published to queue {} with priority {}",
+                    msg,
+                    self.queue_name,
+                    priority,
                 )
         else:
             logger.warning("List of messages is empty so nothing will be published to queue.")

--- a/pixl_core/src/core/uploader/base.py
+++ b/pixl_core/src/core/uploader/base.py
@@ -62,22 +62,27 @@ class Uploader(ABC):
         :raise: if the image has already been exported
         """
         study_tags = self._get_tags_by_study(study_id)
-        self.check_already_exported(study_tags.pseudo_anon_image_id)
+        with logger.contextualize(
+            project_name=self.project_slug,
+            pseudo_mrn=study_tags.patient_id,
+            pseudo_study_uid=study_tags.pseudo_anon_image_id,
+        ):
+            self.check_already_exported(study_tags.pseudo_anon_image_id)
 
-        logger.info(
-            "Starting {} upload of '{}' for {}",
-            self.__class__.__name__.removesuffix("Uploader"),
-            study_tags.pseudo_anon_image_id,
-            self.project_slug,
-        )
-        self._upload_dicom_image(study_id, study_tags)
-        logger.success(
-            "Finished {} upload of '{}'",
-            self.__class__.__name__.removesuffix("Uploader"),
-            study_tags.pseudo_anon_image_id,
-        )
+            logger.info(
+                "Starting {} upload of '{}' for {}",
+                self.__class__.__name__.removesuffix("Uploader"),
+                study_tags.pseudo_anon_image_id,
+                self.project_slug,
+            )
+            self._upload_dicom_image(study_id, study_tags)
+            logger.success(
+                "Finished {} upload of '{}'",
+                self.__class__.__name__.removesuffix("Uploader"),
+                study_tags.pseudo_anon_image_id,
+            )
 
-        update_exported_at(study_tags.pseudo_anon_image_id, datetime.now(tz=UTC))
+            update_exported_at(study_tags.pseudo_anon_image_id, datetime.now(tz=UTC))
 
     @abstractmethod
     def _upload_dicom_image(

--- a/pixl_core/tests/test_logging.py
+++ b/pixl_core/tests/test_logging.py
@@ -71,6 +71,25 @@ def test_otel_sink_logs_messages(exporter: InMemoryLogRecordExporter) -> None:
 
 
 @pytest.mark.usefixtures("otel_logger")
+def test_bound_fields_become_attributes(exporter: InMemoryLogRecordExporter) -> None:
+    """Test that bound fields are exported as top-level OTel log attributes."""
+    logger.bind(
+        project_name="test-project",
+        study_uid="1.2.3",
+    ).info("Processing study.")
+
+    record = exporter.get_finished_logs()[0].log_record
+    attributes = dict(record.attributes)
+
+    assert record.body == "Processing study."
+    assert attributes["study_uid"] == "1.2.3"
+    assert attributes["project_name"] == "test-project"
+    assert attributes["code.function"] == "test_bound_fields_become_attributes"
+    assert attributes["code.lineno"] > 0
+    assert str(attributes["code.filepath"]).endswith("test_logging.py")
+
+
+@pytest.mark.usefixtures("otel_logger")
 def test_severity_mapping(exporter: InMemoryLogRecordExporter) -> None:
     """Test loguru levels map correctly to the configured OTel severity name and number."""
     logger.trace("Trace message.")

--- a/pixl_export/src/pixl_export/main.py
+++ b/pixl_export/src/pixl_export/main.py
@@ -69,19 +69,22 @@ def export_patient_data(export_params: ExportPatientData) -> None:
     NOTE: we can't check that all reports in the queue have been processed, so
     we are relying on the user waiting until processing has finished before running this.
     """
-    logger.info("Exporting Patient Data for '{}'", export_params.project_name)
+    with logger.contextualize(
+        project_name=export_params.project_name,
+    ):
+        logger.info("Exporting Patient Data for '{}'", export_params.project_name)
 
-    # Upload Parquet files to the appropriate endpoint
-    parquet_export = ParquetExport(
-        export_params.project_name, export_params.extract_datetime, export_params.output_dir
-    )
+        # Upload Parquet files to the appropriate endpoint
+        parquet_export = ParquetExport(
+            export_params.project_name, export_params.extract_datetime, export_params.output_dir
+        )
 
-    try:
-        parquet_export.upload()
-    except ValueError as e:
-        msg = "Destination for parquet files unavailable"
-        logger.exception(msg)
-        raise HTTPException(status_code=400, detail=msg) from e
+        try:
+            parquet_export.upload()
+        except ValueError as e:
+            msg = "Destination for parquet files unavailable"
+            logger.exception(msg)
+            raise HTTPException(status_code=400, detail=msg) from e
 
 
 @app.post(
@@ -98,6 +101,10 @@ def export_dicom_from_orthanc(
     Because we're post-anonymisation, the "StudyInstanceUID" tag returned is actually
     the Pseudo Study UID (a randomly selected, but consistent UID).
     """
-    uploader = get_uploader(project_name)
-    logger.debug("Sending {} via '{}'", study_id, type(uploader).__name__)
-    uploader.upload_dicom_and_update_database(study_id)
+    with logger.contextualize(
+        project_name=project_name,
+        orthanc_study_id=study_id,
+    ):
+        uploader = get_uploader(project_name)
+        logger.debug("Sending {} via '{}'", study_id, type(uploader).__name__)
+        uploader.upload_dicom_and_update_database(study_id)

--- a/pixl_export/src/pixl_export/main.py
+++ b/pixl_export/src/pixl_export/main.py
@@ -103,7 +103,7 @@ def export_dicom_from_orthanc(
     """
     with logger.contextualize(
         project_name=project_name,
-        orthanc_study_id=study_id,
+        orthanc_resource_id=study_id,
     ):
         uploader = get_uploader(project_name)
         logger.debug("Sending {} via '{}'", study_id, type(uploader).__name__)

--- a/pixl_imaging/src/pixl_imaging/_processing.py
+++ b/pixl_imaging/src/pixl_imaging/_processing.py
@@ -41,17 +41,24 @@ async def process_message(message: Message, archive: DicomModality) -> None:
     We may receive multiple messages with same Patient + Acc Num, either as retries or because
     they are needed for multiple projects.
     """
-    logger.trace("Processing: {}. Querying {} archive.", message.identifier, archive.name)
+    with logger.contextualize(
+        project_name=message.project_name,
+        mrn=message.mrn,
+        accession_number=message.accession_number,
+        study_uid=message.study_uid,
+        archive=archive.name,
+    ):
+        logger.trace("Processing: {}. Querying {} archive.", message.identifier, archive.name)
 
-    study = ImagingStudy.from_message(message)
-    orthanc_raw = PIXLRawOrthanc()
-    orthanc_anon = PIXLAnonOrthanc()
-    await _process_message(
-        study=study,
-        orthanc_raw=orthanc_raw,
-        archive=archive,
-        orthanc_anon=orthanc_anon,
-    )
+        study = ImagingStudy.from_message(message)
+        orthanc_raw = PIXLRawOrthanc()
+        orthanc_anon = PIXLAnonOrthanc()
+        await _process_message(
+            study=study,
+            orthanc_raw=orthanc_raw,
+            archive=archive,
+            orthanc_anon=orthanc_anon,
+        )
 
 
 async def _process_message(


### PR DESCRIPTION
<!-- Replace {issue_number} with the issue that will be closed after merging this PR -->
## Description
Closes #638

- `OTelSink.__call__` now exposes loguru's bound fields as top-level, queryable attributes in the OTel logs
- contextualise logs with relevant data, using a consistent naming convention across services (`project_name`, `mrn`, `accession_number`, `study_uid`, `pseudo_mrn`, `pseudo_study_uid`, `orthanc_resource_id`)
- Orthanc Anon is the part I was least sure about and probably needs a decent look to make sure the fields I've bound make sense

I've tried to add context where I thought it would be helpful, and to link across services, e.g. link `study_uid` -> `pseudo_study_uid` and `pseudo_study_uid` -> `orthan_resource_id` (as the export API only receives the resource ID, not the study uid). Although in a later PR we can instrument and correlate traces, which will make linking across services easier.

## Type of change
Please delete options accordingly to the description.

<!-- Write an `x` in all the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


### Suggested Checklist
<!-- You do not need to complete all the items by the time you submit the pull request, but most likely the changes will only be merged if all the tasks are done. -->

<!-- Write an `x` in all the boxes that apply -->
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have passed on my local host device. (see further details at the [CONTRIBUTING](https://github.com/SAFEHR-data/PIXL/blob/main/CONTRIBUTING.md#local-testing) document)
- [ ] Make sure your branch is up-to-date with main branch. See [CONTRIBUTING](https://github.com/SAFEHR-data/PIXL/blob/main/CONTRIBUTING.md) for a general example to syncronise your branch with the `main` branch.
- [ ] I have requested review to this PR.
- [ ] I have addressed and marked as resolved all the review comments in my PR.
- [ ] Finally, I have selected `squash and merge`

