### PR TITLE
Encapsulate compressed pixel data

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,9 @@ The configuration file defines:
 - The endpoints used to upload the anonymised DICOM data and the public and radiology
   [parquet files](./docs/file_types/parquet_files.md). We currently support the following endpoints:
     - `"none"`: no upload
-    - `"ftps"`: a secure FTP server (for both _DICOM_ and _parquet_ files)
+    - `"ftps"`: a secure FTP server using implicit TLS (for both _DICOM_ and _parquet_ files), e.g. UCL DSH
+    - `"ftpes"`: a secure FTP server using explicit TLS (for both _DICOM_ and _parquet_ files)
+
     - `"dicomweb"`: a DICOMweb server (for _DICOM_ files only).
       Requires the `DICOMWEB_*` environment variables to be set in `.env`
     - `"xnat"`: an [XNAT](https://www.xnat.org/) instance (for _DICOM_ files only)

--- a/pixl_core/src/core/project_config/pixl_config_model.py
+++ b/pixl_core/src/core/project_config/pixl_config_model.py
@@ -146,6 +146,7 @@ class _DestinationEnum(enum.StrEnum):
 
     none = "none"
     ftps = "ftps"
+    ftpes = "ftpes"
     dicomweb = "dicomweb"
     xnat = "xnat"
     tre = "tre"

--- a/pixl_core/src/core/uploader/__init__.py
+++ b/pixl_core/src/core/uploader/__init__.py
@@ -28,7 +28,7 @@ from typing import TYPE_CHECKING
 from core.project_config import load_project_config
 
 from ._dicomweb import DicomWebUploader
-from ._ftps import FTPSUploader
+from ._ftps import FTPESUploader, FTPSUploader
 from ._treapi import TreApiUploader
 from ._xnat import XNATUploader
 
@@ -41,6 +41,7 @@ def get_uploader(project_slug: str) -> Uploader:
     """Uploader Factory, returns uploader instance based on destination."""
     choices: dict[str, type[Uploader]] = {
         "ftps": FTPSUploader,
+        "ftpes": FTPESUploader,
         "dicomweb": DicomWebUploader,
         "xnat": XNATUploader,
         "tre": TreApiUploader,

--- a/pixl_core/src/core/uploader/_ftps.py
+++ b/pixl_core/src/core/uploader/_ftps.py
@@ -209,12 +209,4 @@ def _create_and_set_as_cwd_multi_path(ftp: FTP_TLS, remote_multi_dir: Path) -> N
         _create_and_set_as_cwd(ftp, sd)
 
 
-def _create_and_set_as_cwd(ftp: FTP_TLS, project_dir: str) -> None:
-    try:
-        ftp.mkd(project_dir)
-    except ftplib.error_perm:
-        logger.debug("'{}' exists on remote ftp, so moving into it", project_dir)
-    else:
-        logger.info("created '{}' on remote ftp and moving into it", project_dir)
-
-    ftp.cwd(project_dir)
+def _create_and_set_as_cwd(ftp: FTP_TLS, project_dir: str) -> None: ...

--- a/pixl_core/src/core/uploader/_ftps.py
+++ b/pixl_core/src/core/uploader/_ftps.py
@@ -211,7 +211,9 @@ def _create_and_set_as_cwd_multi_path(ftp: FTP_TLS, remote_multi_dir: Path) -> N
 
 def _create_and_set_as_cwd(ftp: FTP_TLS, project_dir: str) -> None:
     logger.warning("cwd: {}", ftp.pwd())
-    logger.warning("contents: {}", ftp.list())
+    logger.warning("contents: {}", ftp.retrlines('LIST'))
+    ftp.cwd("ftp")
+
     try:
         ftp.mkd(project_dir)
     except ftplib.error_perm:

--- a/pixl_core/src/core/uploader/_ftps.py
+++ b/pixl_core/src/core/uploader/_ftps.py
@@ -209,4 +209,5 @@ def _create_and_set_as_cwd_multi_path(ftp: FTP_TLS, remote_multi_dir: Path) -> N
         _create_and_set_as_cwd(ftp, sd)
 
 
-def _create_and_set_as_cwd(ftp: FTP_TLS, project_dir: str) -> None: ...
+def _create_and_set_as_cwd(ftp: FTP_TLS, project_dir: str) -> None:
+    logger.warning("cwd: {}", ftp.pwd())

--- a/pixl_core/src/core/uploader/_ftps.py
+++ b/pixl_core/src/core/uploader/_ftps.py
@@ -209,5 +209,4 @@ def _create_and_set_as_cwd_multi_path(ftp: FTP_TLS, remote_multi_dir: Path) -> N
         _create_and_set_as_cwd(ftp, sd)
 
 
-def _create_and_set_as_cwd(ftp: FTP_TLS, project_dir: str) -> None:
-    logger.warning("cwd: {}", ftp.pwd())
+def _create_and_set_as_cwd(ftp: FTP_TLS, project_dir: str) -> None: ...

--- a/pixl_core/src/core/uploader/_ftps.py
+++ b/pixl_core/src/core/uploader/_ftps.py
@@ -210,6 +210,8 @@ def _create_and_set_as_cwd_multi_path(ftp: FTP_TLS, remote_multi_dir: Path) -> N
 
 
 def _create_and_set_as_cwd(ftp: FTP_TLS, project_dir: str) -> None:
+    logger.warning("cwd: {}", ftp.pwd())
+    logger.warning("contents: {}", ftp.list())
     try:
         ftp.mkd(project_dir)
     except ftplib.error_perm:

--- a/pixl_core/src/core/uploader/_ftps.py
+++ b/pixl_core/src/core/uploader/_ftps.py
@@ -210,10 +210,6 @@ def _create_and_set_as_cwd_multi_path(ftp: FTP_TLS, remote_multi_dir: Path) -> N
 
 
 def _create_and_set_as_cwd(ftp: FTP_TLS, project_dir: str) -> None:
-    logger.warning("cwd: {}", ftp.pwd())
-    logger.warning("contents: {}", ftp.retrlines('LIST'))
-    ftp.cwd("ftp")
-
     try:
         ftp.mkd(project_dir)
     except ftplib.error_perm:

--- a/pixl_core/src/core/uploader/_ftps.py
+++ b/pixl_core/src/core/uploader/_ftps.py
@@ -64,6 +64,8 @@ class ImplicitFtpTls(ftplib.FTP_TLS):
 class FTPSUploader(Uploader):
     """Upload strategy for an FTPS server."""
 
+    ftp_tls_class: type[ftplib.FTP_TLS] = ImplicitFtpTls
+
     def __init__(self, project_slug: str, keyvault_alias: str | None) -> None:
         """Create instance of parent class"""
         super().__init__(project_slug, keyvault_alias)
@@ -96,7 +98,7 @@ class FTPSUploader(Uploader):
     ) -> None:
         """Send the zip content to the FTPS server."""
         # Create the remote directory if it doesn't exist
-        ftp = _connect_to_ftp(self.host, self.port, self.user, self.password)
+        ftp = _connect_to_ftp(self.host, self.port, self.user, self.password, self.ftp_tls_class)
         _create_and_set_as_cwd(ftp, remote_directory)
         command = f"STOR {pseudo_anon_image_id}.zip"
         logger.debug("Running {}", command)
@@ -134,7 +136,7 @@ class FTPSUploader(Uploader):
 
         source_root_dir = parquet_export.current_extract_base
         # Create the remote directory if it doesn't exist
-        ftp = _connect_to_ftp(self.host, self.port, self.user, self.password)
+        ftp = _connect_to_ftp(self.host, self.port, self.user, self.password, self.ftp_tls_class)
         _create_and_set_as_cwd(ftp, parquet_export.project_slug)
         _create_and_set_as_cwd(ftp, parquet_export.extract_time_slug)
         _create_and_set_as_cwd(ftp, "parquet")
@@ -169,10 +171,22 @@ class FTPSUploader(Uploader):
         logger.info("Finished FTPS upload of files for '{}'", parquet_export.project_slug)
 
 
-def _connect_to_ftp(ftp_host: str, ftp_port: int, ftp_user: str, ftp_password: str) -> FTP_TLS:
+class FTPESUploader(FTPSUploader):
+    """Upload strategy for an FTPES server (explicit rather than implicit TLS)."""
+
+    ftp_tls_class = ftplib.FTP_TLS
+
+
+def _connect_to_ftp(
+    ftp_host: str,
+    ftp_port: int,
+    ftp_user: str,
+    ftp_password: str,
+    ftp_tls_class: type[ftplib.FTP_TLS],
+) -> FTP_TLS:
     # Connect to the server and login
     try:
-        ftp = ftplib.FTP_TLS()
+        ftp = ftp_tls_class()
         ftp.connect(ftp_host, int(ftp_port))
         ftp.login(ftp_user, ftp_password)
         ftp.prot_p()

--- a/pixl_core/src/core/uploader/_ftps.py
+++ b/pixl_core/src/core/uploader/_ftps.py
@@ -209,4 +209,12 @@ def _create_and_set_as_cwd_multi_path(ftp: FTP_TLS, remote_multi_dir: Path) -> N
         _create_and_set_as_cwd(ftp, sd)
 
 
-def _create_and_set_as_cwd(ftp: FTP_TLS, project_dir: str) -> None: ...
+def _create_and_set_as_cwd(ftp: FTP_TLS, project_dir: str) -> None:
+    try:
+        ftp.mkd(project_dir)
+    except ftplib.error_perm:
+        logger.debug("'{}' exists on remote ftp, so moving into it", project_dir)
+    else:
+        logger.info("created '{}' on remote ftp and moving into it", project_dir)
+
+    ftp.cwd(project_dir)

--- a/pixl_core/src/core/uploader/_ftps.py
+++ b/pixl_core/src/core/uploader/_ftps.py
@@ -38,6 +38,7 @@ from loguru import logger
 class ImplicitFtpTls(ftplib.FTP_TLS):
     """
     FTP_TLS subclass that automatically wraps sockets in SSL to support implicit FTPS.
+    Use explicit TLS where possible.
 
     https://stackoverflow.com/questions/12164470/python-ftp-implicit-tls-connection-issue
     """
@@ -171,7 +172,7 @@ class FTPSUploader(Uploader):
 def _connect_to_ftp(ftp_host: str, ftp_port: int, ftp_user: str, ftp_password: str) -> FTP_TLS:
     # Connect to the server and login
     try:
-        ftp = ImplicitFtpTls()
+        ftp = ftplib.FTP_TLS()
         ftp.connect(ftp_host, int(ftp_port))
         ftp.login(ftp_user, ftp_password)
         ftp.prot_p()

--- a/pixl_dcmd/src/pixl_dcmd/main.py
+++ b/pixl_dcmd/src/pixl_dcmd/main.py
@@ -262,7 +262,7 @@ def _clean_dicom_image_pixels(
     burned_pixels = has_burned_pixels(dataset, deid=deid_recipe)
     cleaned_pixels = clean_pixel_data(dicom_file=dataset, results=burned_pixels)
 
-    dataset.PixelData = cleaned_pixels.tobytes()
+    dataset.PixelData = pydicom.encaps.encapsulate([cleaned_pixels.tobytes()])
 
 
 def _anonymise_dicom_from_scheme(

--- a/pixl_dcmd/src/pixl_dcmd/main.py
+++ b/pixl_dcmd/src/pixl_dcmd/main.py
@@ -262,7 +262,11 @@ def _clean_dicom_image_pixels(
     burned_pixels = has_burned_pixels(dataset, deid=deid_recipe)
     cleaned_pixels = clean_pixel_data(dicom_file=dataset, results=burned_pixels)
 
-    dataset.PixelData = pydicom.encaps.encapsulate([cleaned_pixels.tobytes()])
+    pixel_bytes = cleaned_pixels.tobytes()
+    if dataset.file_meta.TransferSyntaxUID.is_compressed:
+        dataset.PixelData = pydicom.encaps.encapsulate([pixel_bytes])
+    else:
+        dataset.PixelData = pixel_bytes
 
 
 def _anonymise_dicom_from_scheme(

--- a/projects/configs/tag-operations/us.yaml
+++ b/projects/configs/tag-operations/us.yaml
@@ -24,3 +24,47 @@
   group: 0x0018
   element: 0x6011
   op: keep
+- name: Region Spatial Format
+  group: 0x0018
+  element: 0x6012
+  op: keep
+- name: Region Data Type
+  group: 0x0018
+  element: 0x6014
+  op: keep
+- name: Region Flags
+  group: 0x0018
+  element: 0x6016
+  op: keep
+- name: Region Location Min X0
+  group: 0x0018
+  element: 0x6018
+  op: keep
+- name: Region Location Min Y0
+  group: 0x0018
+  element: 0x601A
+  op: keep
+- name: Region Location Max X1
+  group: 0x0018
+  element: 0x601C
+  op: keep
+- name: Region Location Max Y1
+  group: 0x0018
+  element: 0x601E
+  op: keep
+- name: Physical Units X Direction
+  group: 0x0018
+  element: 0x6024
+  op: keep
+- name: Physical Units Y Direction
+  group: 0x0018
+  element: 0x6026
+  op: keep
+- name: Physical Delta X
+  group: 0x0018
+  element: 0x602C
+  op: keep
+- name: Physical Delta Y
+  group: 0x0018
+  element: 0x602E
+  op: keep

--- a/projects/configs/ultrasound-learning-for-timely-rapid-assessment-of-cts.yaml
+++ b/projects/configs/ultrasound-learning-for-timely-rapid-assessment-of-cts.yaml
@@ -39,5 +39,5 @@ series_filters:
     - "positioning"
 
 destination:
-    dicom: "ftps"
-    parquet: "ftps"
+    dicom: "ftpes"
+    parquet: "ftpes"


### PR DESCRIPTION
At point of writing the entire pydicom object to bytes was getting an error compressed Pixel Data not being encapsulated 

```
orthanc-anon-1  |   File "/.venv/lib64/python3.13/site-packages/pydicom/filewriter.py", line 659, in write_dataset
orthanc-anon-1  |     with tag_in_exception(tag):
orthanc-anon-1  |          |                -> (7fe0, 0010)
orthanc-anon-1  |          -> <function tag_in_exception at 0x7fe517c236a0>
orthanc-anon-1  |
orthanc-anon-1  |   File "/usr/lib/python3.13/contextlib.py", line 162, in __exit__
orthanc-anon-1  |     self.gen.throw(value)
orthanc-anon-1  |     |    |   |     -> ValueError("(7FE0,0010) Pixel Data has an undefined length indicating that it's compressed, but the data isn't encapsulated a...
orthanc-anon-1  |     |    |   -> <method 'throw' of 'generator' objects>
orthanc-anon-1  |     |    -> <generator object tag_in_exception at 0x7fe4d7e71140>
orthanc-anon-1  |     -> <contextlib._GeneratorContextManager object at 0x7fe3b42ea4a0>
orthanc-anon-1  |
orthanc-anon-1  |   File "/.venv/lib64/python3.13/site-packages/pydicom/tag.py", line 32, in tag_in_exception
orthanc-anon-1  |     raise type(exc)(msg) from exc
orthanc-anon-1  |                     -> 'With tag (7fe0, 0010) got exception: (7FE0,0010) Pixel Data has an undefined length indicating that it\'s compressed, but th...
orthanc-anon-1  |
orthanc-anon-1  | ValueError: With tag (7fe0, 0010) got exception: (7FE0,0010) Pixel Data has an undefined length indicating that it's compressed, but the data isn't encapsulated as required. See pydicom.en
caps.encapsulate() for more information

```